### PR TITLE
Switch from stateless to stateful `Clock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Changed
 
+- Add `&mut self` to `Clock` functions (make stateful, or at least allow stateful implementations)
 - All time-type inner types from signed to unsigned
 - `Instant::duration_since()` return type to `Result`
 - Refactor `examples/nrf52_dk`

--- a/examples/nrf52_dk/main.rs
+++ b/examples/nrf52_dk/main.rs
@@ -3,10 +3,8 @@
 
 extern crate panic_rtt;
 
-use cortex_m::mutex::CriticalSectionMutex as Mutex;
 use cortex_m_rt::entry;
-use embedded_time::{self as time, traits::*, Clock, Instant, Period};
-use mutex_trait::Mutex as _;
+use embedded_time::{self as time, traits::*};
 
 pub mod nrf52 {
     pub use nrf52832_hal::{
@@ -14,46 +12,41 @@ pub mod nrf52 {
         prelude::*,
         target::{self as pac, Peripherals},
     };
+}
 
-    pub struct Clock64 {
-        low: pac::TIMER0,
-        high: pac::TIMER1,
-        capture_task: pac::EGU0,
-    }
+pub struct SysClock {
+    low: nrf52::pac::TIMER0,
+    high: nrf52::pac::TIMER1,
+    capture_task: nrf52::pac::EGU0,
+}
 
-    impl Clock64 {
-        pub fn take(low: pac::TIMER0, high: pac::TIMER1, capture_task: pac::EGU0) -> Self {
-            Self {
-                low,
-                high,
-                capture_task,
-            }
-        }
-
-        pub(crate) fn read(&mut self) -> u64 {
-            self.capture_task.tasks_trigger[0].write(|write| unsafe { write.bits(1) });
-            self.low.cc[0].read().bits() as u64 | ((self.high.cc[0].read().bits() as u64) << 32)
+impl SysClock {
+    pub fn take(
+        low: nrf52::pac::TIMER0,
+        high: nrf52::pac::TIMER1,
+        capture_task: nrf52::pac::EGU0,
+    ) -> Self {
+        Self {
+            low,
+            high,
+            capture_task,
         }
     }
 }
-
-pub struct SysClock;
 
 impl time::Clock for SysClock {
     type Rep = u64;
-    const PERIOD: Period = <Period>::new(1, 16_000_000);
+    const PERIOD: time::Period = <time::Period>::new(1, 16_000_000);
 
-    fn now() -> Instant<Self> {
-        let ticks = (&CLOCK64).lock(|clock| match clock {
-            Some(clock) => clock.read(),
-            None => 0,
-        });
+    fn now(&mut self) -> time::Instant<Self> {
+        self.capture_task.tasks_trigger[0].write(|write| unsafe { write.bits(1) });
 
-        Instant::new(ticks as Self::Rep)
+        let ticks =
+            self.low.cc[0].read().bits() as u64 | ((self.high.cc[0].read().bits() as u64) << 32);
+
+        time::Instant::new(ticks as Self::Rep)
     }
 }
-
-static CLOCK64: Mutex<Option<nrf52::Clock64>> = Mutex::new(None);
 
 #[entry]
 fn main() -> ! {
@@ -106,8 +99,7 @@ fn main() -> ! {
     // This moves these peripherals to prevent conflicting usage, however not the entire EGU0 is
     // used. A ref to EGU0 could be sent instead, although that provides no protection for the
     // fields that are being used by Clock64.
-    let clock64 = nrf52::Clock64::take(device.TIMER0, device.TIMER1, device.EGU0);
-    (&CLOCK64).lock(|ticks| *ticks = Some(clock64));
+    let mut clock = SysClock::take(device.TIMER0, device.TIMER1, device.EGU0);
 
     let port0 = nrf52::gpio::p0::Parts::new(device.P0);
 
@@ -136,6 +128,7 @@ fn main() -> ! {
         &mut led2.degrade(),
         &mut led3.degrade(),
         &mut led4.degrade(),
+        &mut clock,
     )
     .unwrap();
 
@@ -147,6 +140,7 @@ fn run<Led>(
     led2: &mut Led,
     led3: &mut Led,
     led4: &mut Led,
+    clock: &mut SysClock,
 ) -> Result<(), <Led as nrf52::OutputPin>::Error>
 where
     Led: nrf52::OutputPin,
@@ -156,12 +150,12 @@ where
         led2.set_high()?;
         led3.set_high()?;
         led4.set_low()?;
-        SysClock::delay(250_u32.milliseconds());
+        clock.delay(250_u32.milliseconds());
 
         led1.set_high()?;
         led2.set_low()?;
         led3.set_low()?;
         led4.set_high()?;
-        SysClock::delay(250_u32.milliseconds());
+        clock.delay(250_u32.milliseconds());
     }
 }

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -10,15 +10,15 @@ pub trait Clock: Sized {
     const PERIOD: Period;
 
     /// Get the current Instant
-    fn now() -> Instant<Self>;
+    fn now(&mut self) -> Instant<Self>;
 
     /// Blocking delay
-    fn delay<Dur: Duration>(dur: Dur)
+    fn delay<Dur: Duration>(&mut self, dur: Dur)
     where
         Self::Rep: TryFrom<Dur::Rep>,
     {
-        let start = Self::now();
+        let start = self.now();
         let end = start + dur;
-        while Self::now() < end {}
+        while self.now() < end {}
     }
 }

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -38,7 +38,7 @@ impl<Clock: crate::Clock> Instant<Clock> {
     ///     type Rep = u32;
     ///     const PERIOD: Period = <Period>::new(1, 1_000);
     ///     // ...
-    /// # fn now() -> Instant<Self> {unimplemented!()}
+    /// # fn now(&mut self) -> Instant<Self> {unimplemented!()}
     /// }
     ///
     /// assert_eq!(Instant::<Clock>::new(5).duration_since::<Microseconds<u64>>(&Instant::<Clock>::new(3)),
@@ -74,7 +74,7 @@ impl<Clock: crate::Clock> Instant<Clock> {
     ///     type Rep = u32;
     ///     const PERIOD: Period =<Period>::new(1, 1_000);
     ///     // ...
-    /// # fn now() -> Instant<Self> {unimplemented!()}
+    /// # fn now(&mut self) -> Instant<Self> {unimplemented!()}
     /// }
     ///
     /// assert_eq!(Instant::<Clock>::new(5).duration_until::<Microseconds<u64>>(&Instant::<Clock>::new(7)),
@@ -99,6 +99,7 @@ impl<Clock: crate::Clock> Instant<Clock> {
     pub fn duration_since_epoch<Dur: Duration>(&self) -> Result<Dur, ()>
     where
         Dur::Rep: TryFrom<Clock::Rep>,
+        Clock::Rep: TryFrom<Dur::Rep>,
     {
         Self::duration_since::<Dur>(
             &self,
@@ -137,7 +138,7 @@ impl<Clock: crate::Clock> PartialOrd for Instant<Clock> {
     ///     type Rep = u32;
     ///     const PERIOD: Period =<Period>::new(1, 1_000);
     ///     // ...
-    /// # fn now() -> Instant<Self> {unimplemented!()}
+    /// # fn now(&mut self) -> Instant<Self> {unimplemented!()}
     /// }
     ///
     /// assert!(Instant::<Clock>::new(5) > Instant::<Clock>::new(3));
@@ -177,7 +178,7 @@ where
     ///     type Rep = u32;
     ///     const PERIOD: Period =<Period>::new(1, 1_000);
     ///     // ...
-    /// # fn now() -> Instant<Self> {unimplemented!()}
+    /// # fn now(&mut self) -> Instant<Self> {unimplemented!()}
     /// }
     ///
     /// Instant::<Clock>::new(1) + Seconds(u32::MAX);
@@ -193,7 +194,7 @@ where
     ///     type Rep = u32;
     ///     const PERIOD: Period =<Period>::new(1, 1_000);
     ///     // ...
-    /// # fn now() -> Instant<Self> {unimplemented!()}
+    /// # fn now(&mut self) -> Instant<Self> {unimplemented!()}
     /// }
     ///
     /// let _ = Instant::<Clock>::new(0) + Milliseconds(i32::MAX as u32 + 1);
@@ -210,7 +211,7 @@ where
     ///     type Rep = u32;
     ///     const PERIOD: Period =<Period>::new(1, 1_000);
     ///     // ...
-    /// # fn now() -> Instant<Self> {unimplemented!()}
+    /// # fn now(&mut self) -> Instant<Self> {unimplemented!()}
     /// }
     ///
     /// assert_eq!(Instant::<Clock>::new(1) + Seconds(3_u32), Instant::<Clock>::new(3_001));
@@ -250,7 +251,7 @@ where
     ///     type Rep = u32;
     ///     const PERIOD: Period =<Period>::new(1, 1_000);
     ///     // ...
-    /// # fn now() -> Instant<Self> {unimplemented!()}
+    /// # fn now(&mut self) -> Instant<Self> {unimplemented!()}
     /// }
     ///
     /// Instant::<Clock>::new(1) - Seconds(u32::MAX);
@@ -266,7 +267,7 @@ where
     ///     type Rep = u32;
     ///     const PERIOD: Period = <Period>::new(1, 1_000);
     ///     // ...
-    /// # fn now() -> Instant<Self> {unimplemented!()}
+    /// # fn now(&mut self) -> Instant<Self> {unimplemented!()}
     /// }
     ///
     /// let _ = Instant::<Clock>::new(u32::MAX) - Milliseconds(i32::MAX as u32 + 1);
@@ -283,7 +284,7 @@ where
     ///     type Rep = u32;
     ///     const PERIOD: Period =<Period>::new(1, 1_000);
     ///     // ...
-    /// # fn now() -> Instant<Self> {unimplemented!()}
+    /// # fn now(&mut self) -> Instant<Self> {unimplemented!()}
     /// }
     ///
     /// assert_eq!(Instant::<Clock>::new(800) - Milliseconds(700_u32), Instant::<Clock>::new(100));
@@ -314,7 +315,7 @@ mod tests {
         type Rep = u32;
         const PERIOD: Period = <Period>::new(1, 1_000);
 
-        fn now() -> Instant<Self> {
+        fn now(&mut self) -> Instant<Self> {
             unimplemented!()
         }
     }


### PR DESCRIPTION
Currently, the `Clock` trait is composed of only associated functions. Per https://github.com/FluenTech/embedded-time/pull/21#issuecomment-651229314, they need to be changed to methods. Specifically, `now()` needs to take `&mut self`.
