### PR TITLE
An overhaul of crate-wide error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "embedded-time"
-version = "0.6.0"
+version = "0.7.0-alpha"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,7 @@ dependencies = [
  "crossbeam-utils",
  "nrf52832-hal",
  "num",
+ "panic-never",
  "panic_rtt",
 ]
 
@@ -266,6 +267,12 @@ checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "panic-never"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0dc75d1f6543e7468fe83fe67257da512d7f1d2d5b66adfbbcf86b22df8d370"
 
 [[package]]
 name = "panic_rtt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ license = "MIT OR Apache-2.0"
 num = { version = "0.3.0", default-features = false }
 
 [dev-dependencies]
+panic-never = "0.1.0"
 cortex-m = "0.6.2"
 cortex-m-rt = "0.6.12"
 panic_rtt = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-time"
-version = "0.6.0"
+version = "0.7.0-alpha"
 authors = ["Peter Taylor <PTaylor@FluenTech.info>"]
 edition = "2018"
 description = "A library for abstracting clocks and handling time(ing) in embedded systems"

--- a/examples/isolated/.cargo/config
+++ b/examples/isolated/.cargo/config
@@ -1,0 +1,14 @@
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+rustflags = [
+  # LLD (shipped with the Rust toolchain) is used as the default linker
+  "-C", "link-arg=-Tlink.x",
+]
+
+[build]
+target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
+
+[profile.release]
+codegen-units = 1 # better optimizations
+debug = true # symbols are nice and they don't increase the size on Flash
+lto = true # better optimizations
+opt-level = "z"

--- a/examples/isolated/main.rs
+++ b/examples/isolated/main.rs
@@ -1,0 +1,27 @@
+#![no_std]
+#![no_main]
+
+use core::convert::Infallible;
+use cortex_m_rt::entry;
+use embedded_time::{self as time, traits::*};
+use nrf52832_hal as _;
+use panic_never as _;
+
+pub struct SysClock;
+impl time::Clock for SysClock {
+    type Rep = u64;
+    const PERIOD: time::Period = <time::Period>::new(1, 1_000_000);
+    type ImplError = Infallible;
+
+    fn now(&self) -> Result<time::Instant<Self>, time::clock::Error<Self::ImplError>> {
+        Ok(time::Instant::new(23 as Self::Rep))
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    let clock = SysClock;
+
+    let _timer = clock.new_timer(23_u32.milliseconds()).start();
+    loop {}
+}

--- a/examples/nrf52_dk/main.rs
+++ b/examples/nrf52_dk/main.rs
@@ -151,12 +151,20 @@ where
         led2.set_high()?;
         led3.set_high()?;
         led4.set_low()?;
-        clock.new_timer(250_u32.milliseconds()).start().wait();
+        clock
+            .new_timer(250_u32.milliseconds())
+            .start()
+            .unwrap()
+            .wait();
 
         led1.set_high()?;
         led2.set_low()?;
         led3.set_low()?;
         led4.set_high()?;
-        clock.new_timer(250_u32.milliseconds()).start().wait();
+        clock
+            .new_timer(250_u32.milliseconds())
+            .start()
+            .unwrap()
+            .wait();
     }
 }

--- a/examples/nrf52_dk/main.rs
+++ b/examples/nrf52_dk/main.rs
@@ -155,7 +155,8 @@ where
             .new_timer(250_u32.milliseconds())
             .start()
             .unwrap()
-            .wait();
+            .wait()
+            .unwrap();
 
         led1.set_high()?;
         led2.set_low()?;
@@ -165,6 +166,7 @@ where
             .new_timer(250_u32.milliseconds())
             .start()
             .unwrap()
-            .wait();
+            .wait()
+            .unwrap();
     }
 }

--- a/examples/nrf52_dk/main.rs
+++ b/examples/nrf52_dk/main.rs
@@ -4,7 +4,7 @@
 use core::convert::Infallible;
 use cortex_m_rt::entry;
 use embedded_time::{self as time, traits::*};
-use panic_never as _;
+use panic_rtt as _;
 
 pub mod nrf52 {
     pub use nrf52832_hal::{

--- a/examples/nrf52_dk/main.rs
+++ b/examples/nrf52_dk/main.rs
@@ -1,11 +1,10 @@
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(not(test), no_main)]
 
-extern crate panic_rtt;
-
 use core::convert::Infallible;
 use cortex_m_rt::entry;
 use embedded_time::{self as time, traits::*};
+use panic_never as _;
 
 pub mod nrf52 {
     pub use nrf52832_hal::{

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -12,6 +12,7 @@ pub enum Error<E: crate::Error> {
     /// implementation-specific error
     Other(E),
 }
+impl<E: crate::Error> crate::Error for Error<E> {}
 
 /// The `Clock` trait provides an abstraction of hardware-specific timer peripherals, external timer
 /// devices, RTCs, etc.

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -257,8 +257,7 @@ pub trait Duration: Sized + Copy + fmt::Display {
             } else {
                 Ok(Self::new(TimeInt::checked_mul_period(
                     &converted_ticks,
-                    &<Period as num::CheckedDiv>::checked_div(&period, &Self::PERIOD)
-                        .ok_or(ConversionError::DivByZero)?,
+                    &period.checked_div(&Self::PERIOD)?,
                 )?))
             }
         } else {
@@ -273,11 +272,7 @@ pub trait Duration: Sized + Copy + fmt::Display {
                     &period,
                 )?
             } else {
-                TimeInt::checked_mul_period(
-                    &ticks,
-                    &<Period as num::CheckedDiv>::checked_div(&period, &Self::PERIOD)
-                        .ok_or(ConversionError::DivByZero)?,
-                )?
+                TimeInt::checked_mul_period(&ticks, &period.checked_div(&Self::PERIOD)?)?
             };
 
             let converted_ticks =
@@ -339,11 +334,7 @@ pub trait Duration: Sized + Copy + fmt::Display {
                     &period,
                 )
             } else {
-                TimeInt::checked_mul_period(
-                    &ticks,
-                    &<Period as num::CheckedDiv>::checked_div(&Self::PERIOD, &period)
-                        .ok_or(ConversionError::DivByZero)?,
-                )
+                TimeInt::checked_mul_period(&ticks, &Self::PERIOD.checked_div(&period)?)
             }
         } else {
             let ticks = if Self::PERIOD > <Period>::new(1, 1) {
@@ -352,11 +343,7 @@ pub trait Duration: Sized + Copy + fmt::Display {
                     &period,
                 )?
             } else {
-                TimeInt::checked_mul_period(
-                    &self.count(),
-                    &<Period as num::CheckedDiv>::checked_div(&Self::PERIOD, &period)
-                        .ok_or(ConversionError::DivByZero)?,
-                )?
+                TimeInt::checked_mul_period(&self.count(), &Self::PERIOD.checked_div(&period)?)?
             };
 
             Rep::try_from(ticks).map_err(|_| ConversionError::ConversionFailure)

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -11,6 +11,7 @@ use num::Bounded;
 ///
 ///
 /// # Constructing a duration
+///
 /// ```rust
 /// # use embedded_time::{traits::*, units::*};
 /// #
@@ -19,6 +20,7 @@ use num::Bounded;
 /// ```
 ///
 /// # Get the integer count
+///
 /// ```rust
 /// # use embedded_time::{traits::*, units::*};
 /// #
@@ -26,7 +28,9 @@ use num::Bounded;
 /// ```
 ///
 /// # Formatting
+///
 /// Just forwards the underlying integer to [`core::fmt::Display::fmt()`]
+///
 /// ```rust
 /// # use embedded_time::{traits::*, units::*};
 /// #
@@ -34,6 +38,7 @@ use num::Bounded;
 /// ```
 ///
 /// # Getting H:M:S.MS... Components
+///
 /// ```rust
 /// # use embedded_time::{traits::*, units::*};
 /// #
@@ -46,9 +51,11 @@ use num::Bounded;
 /// ```
 ///
 /// # Converting to `core` types
+///
 /// [`core::time::Duration`]
 ///
 /// ## Examples
+///
 /// ```rust
 /// # use embedded_time::traits::*;
 /// # use core::convert::TryFrom;
@@ -57,6 +64,7 @@ use num::Bounded;
 /// assert_eq!(core_duration.as_secs(), 2);
 /// assert_eq!(core_duration.subsec_nanos(), 569_000_000);
 /// ```
+///
 /// ```rust
 /// # use embedded_time::traits::*;
 /// # use core::convert::TryInto;
@@ -67,9 +75,11 @@ use num::Bounded;
 /// ```
 ///
 /// # Converting from `core` types
+///
 /// [`core::time::Duration`]
 ///
 /// ## Examples
+///
 /// ```rust
 /// # use embedded_time::{traits::*, units::*};
 /// # use core::convert::TryFrom;
@@ -77,6 +87,7 @@ use num::Bounded;
 /// let core_duration = core::time::Duration::new(5, 730023852);
 /// assert_eq!(Milliseconds::<u32>::try_from(core_duration), Ok(5_730.milliseconds()));
 /// ```
+///
 /// ```rust
 /// # use embedded_time::{traits::*, units::*};
 /// # use core::convert::TryInto;
@@ -86,7 +97,9 @@ use num::Bounded;
 /// ```
 ///
 /// ## Errors
-/// The duration doesn't fit in the type specified
+///
+/// [`ConversionError::ConversionFailure`] : The duration doesn't fit in the type specified
+///
 /// ```rust
 /// # use embedded_time::{traits::*, units::*, ConversionError};
 /// # use core::convert::{TryFrom, TryInto};
@@ -102,44 +115,35 @@ use num::Bounded;
 ///
 /// # Add/Sub
 ///
-/// ## Panics
-/// Panics if the rhs duration cannot be converted into the lhs duration type
-///
-/// In this example, the maximum `u32` value of seconds is stored as `u32` and
-/// converting that value to milliseconds (with `u32` storage type) causes an overflow.
-/// ```rust,should_panic
-/// # use embedded_time::{traits::*, units::*};
-/// #
-/// let _ = Milliseconds(24_u32) + Seconds(u32::MAX);
-/// ```
-///
-/// This example works just fine as the seconds value is first cast to `u64`, then
-/// converted to milliseconds.
-/// ```rust
-/// # use embedded_time::{traits::*, units::*};
-/// #
-/// let _ = Milliseconds(24_u64) + Seconds(u32::MAX);
-/// ```
-///
-/// Here, there is no units conversion to worry about, but `u32::MAX + 1` cannot be
-/// cast to an `u32`.
-/// ```rust,should_panic
-/// # use embedded_time::{traits::*, units::*};
-/// #
-/// let _ = Seconds(u32::MAX) - Seconds(u32::MAX as u64 + 1);
-/// ```
+/// The result of the operation is the LHS type
 ///
 /// ## Examples
+///
 /// ```rust
 /// # use embedded_time::{traits::*, units::*};
 /// #
-/// assert_eq!((Milliseconds(3_234_u32) - Seconds(2_u32)), Milliseconds(1_234_u32));
-/// assert_eq!((Milliseconds(3_234_u64) - Seconds(2_u32)), Milliseconds(1_234_u64));
-/// assert_eq!((Seconds(u32::MAX) - Milliseconds((u32::MAX as u64) + 1)),
-///     Seconds(4_290_672_328_u32));
+/// assert_eq!((Milliseconds(2_001_u32) - Seconds(1_u32)),
+///     Milliseconds(1_001_u32));
+///
+/// assert_eq!((Milliseconds(1_u32) + Seconds(1_u32)),
+///     Milliseconds(1_001_u32));
+/// ```
+///
+/// ## Panics
+///
+/// The same reason the integer operation would panic. Namely, if the
+/// result overflows the type.
+///
+/// ### Examples
+///
+/// ```rust,should_panic
+/// # use embedded_time::{traits::*, units::*};
+/// #
+/// let _ = Seconds(u32::MAX) + Seconds(1_u32);
 /// ```
 ///
 /// # Equality
+///
 /// ```rust
 /// # use embedded_time::{traits::*, units::*};
 /// #
@@ -154,6 +158,7 @@ use num::Bounded;
 /// ```
 ///
 /// # Comparisons
+///
 /// ```rust
 /// # use embedded_time::{traits::*, units::*};
 /// #
@@ -166,6 +171,7 @@ use num::Bounded;
 /// ```
 ///
 /// # Remainder
+///
 /// ```rust
 /// # use embedded_time::{traits::*, units::*};
 /// #
@@ -180,11 +186,13 @@ pub trait Duration: Sized + Copy + fmt::Display {
     const PERIOD: Period;
 
     /// Not generally useful or needed as the duration can be constructed like this:
+    ///
     /// ```no_run
     /// # use embedded_time::{traits::*, units::*};
     /// Seconds(123_u32);
     /// 123_u32.seconds();
     /// ```
+    ///
     /// It only exists to allow Duration methods with default definitions to create a
     /// new duration
     fn new(value: Self::Rep) -> Self;
@@ -192,6 +200,7 @@ pub trait Duration: Sized + Copy + fmt::Display {
     /// Returns the integer value of the `Duration`
     ///
     /// # Examples
+    ///
     /// ```rust
     /// # use embedded_time::{traits::*, units::*};
     /// assert_eq!(Seconds(123_u32).count(), 123_u32);
@@ -201,6 +210,7 @@ pub trait Duration: Sized + Copy + fmt::Display {
     /// Constructs a `Duration` from a value of ticks and a period
     ///
     /// # Examples
+    ///
     /// ```rust
     /// # use embedded_time::{traits::*, units::*, Period};
     /// assert_eq!(Microseconds::<u32>::from_ticks(5_u64, <Period>::new(1, 1_000)),
@@ -212,16 +222,20 @@ pub trait Duration: Sized + Copy + fmt::Display {
     /// ```
     ///
     /// # Errors
+    ///
     /// Failure will only occur if the value does not fit in the selected destination type.
     ///
-    /// the conversion of periods causes an overflow:
+    /// [`ConversionError::Overflow`] : The conversion of periods causes an overflow:
+    ///
     /// ```rust
     /// # use embedded_time::{traits::*, units::*, Period, ConversionError};
     /// assert_eq!(Milliseconds::<u32>::from_ticks(u32::MAX, <Period>::new(1, 1)),
     ///     Err(ConversionError::Overflow));
     /// ```
     ///
-    /// the Self integer cast to that of the provided type fails
+    /// [`ConversionError::ConversionFailure`] : The Self integer cast to that of the destination
+    /// type fails:
+    ///
     /// ```rust
     /// # use embedded_time::{traits::*, units::*, Period, ConversionError};
     /// assert_eq!(Seconds::<u32>::from_ticks(u32::MAX as u64 + 1, <Period>::new(1, 1)),
@@ -275,35 +289,40 @@ pub trait Duration: Sized + Copy + fmt::Display {
     /// Create an integer representation with LSbit period of that provided
     ///
     /// # Examples
+    ///
     /// ```rust
     /// # use embedded_time::{traits::*, units::*, Period, ConversionError};
-    /// assert_eq!(Microseconds(5_000_u32).into_ticks::<u32>(Period::new(1, 1_000)),
+    /// assert_eq!(Microseconds(5_000_u32).into_ticks::<u32>(<Period>::new(1, 1_000)),
     ///     Ok(5_u32));
     ///
     /// // the _into_ period can be any value
-    /// assert_eq!(Microseconds(5_000_u32).into_ticks::<u32>(Period::new(1, 200)),
+    /// assert_eq!(Microseconds(5_000_u32).into_ticks::<u32>(<Period>::new(1, 200)),
     ///     Ok(1_u32));
     ///
     /// // as long as the result fits in the provided integer, it will succeed
-    /// assert_eq!(Microseconds::<u32>(u32::MAX).into_ticks::<u64>(Period::new(1, 2_000_000)),
+    /// assert_eq!(Microseconds::<u32>(u32::MAX).into_ticks::<u64>(<Period>::new(1, 2_000_000)),
     ///     Ok((u32::MAX as u64) * 2));
     /// ```
     ///
     /// # Errors
+    ///
     /// Failure will only occur if the value does not fit in the selected destination type.
     ///
-    /// The conversion of periods causes an overflow:
+    /// [`ConversionError::Overflow`] : The conversion of periods causes an overflow:
+    ///
     /// ```rust
     /// # use embedded_time::{traits::*, units::*, Period, ConversionError};
-    /// assert_eq!(Err(ConversionError::Overflow),
-    ///     Seconds(u32::MAX).into_ticks::<u32>(Period::new(1, 1_000)));
+    /// assert_eq!(Seconds(u32::MAX).into_ticks::<u32>(<Period>::new(1, 1_000)),
+    ///     Err(ConversionError::Overflow));
     /// ```
     ///
-    /// the Self integer cast to that of the provided type fails
+    /// [`ConversionError::ConversionFailure`] : The Self integer cast to that of the destination
+    /// type fails:
+    ///
     /// ```rust
     /// # use embedded_time::{traits::*, units::*, Period, ConversionError};
-    /// assert_eq!(Err(ConversionError::ConversionFailure),
-    ///     Seconds(u32::MAX as u64 + 1).into_ticks::<u32>(Period::new(1, 1)));
+    /// assert_eq!(Seconds(u32::MAX as u64 + 1).into_ticks::<u32>(<Period>::new(1, 1)),
+    ///     Err(ConversionError::ConversionFailure));
     /// ```
     fn into_ticks<Rep: TimeInt>(self, period: Period) -> Result<Rep, ConversionError>
     where
@@ -385,37 +404,44 @@ where
 {
     /// Attempt to convert from one duration type to another
     ///
-    /// Both the underlying storage type and/or the LSbit period can be converted
+    /// Both the inner type and/or the LSbit period (units) can be converted
     ///
     /// # Examples
     /// ```rust
     /// # use embedded_time::{traits::*, units::*};
     /// assert_eq!(Seconds::<u32>::try_convert_from(Milliseconds(23_000_u64)),
     ///     Ok(Seconds(23_u32)));
+    ///
     /// assert_eq!(Seconds::<u64>::try_convert_from(Milliseconds(23_000_u32)),
     ///     Ok(Seconds(23_u64)));
+    ///
     /// assert_eq!(Seconds::<u32>::try_convert_from(Milliseconds(230_u32)),
     ///     Ok(Seconds(0)));
     /// ```
     ///
     /// # Errors
+    ///
     /// Failure will only occur if the value does not fit in the selected destination type.
     ///
-    /// the conversion of periods causes an overflow:
+    /// [`ConversionError::Overflow`] : The conversion of periods causes an overflow:
+    ///
     /// ```rust
     /// # use embedded_time::{traits::*, units::*, ConversionError};
     /// assert_eq!(Milliseconds::<u32>::try_convert_from(Seconds(u32::MAX)),
     ///     Err(ConversionError::Overflow));
     /// ```
     ///
-    /// the Self integer cast to that of the provided type fails
+    /// [`ConversionError::ConversionFailure`] : The Self integer cast to that of the destination
+    /// type fails:
+    ///
     /// ```rust
     /// # use embedded_time::{traits::*, units::*, ConversionError};
     /// assert_eq!(Seconds::<u32>::try_convert_from(Seconds(u32::MAX as u64 + 1)),
     ///     Err(ConversionError::ConversionFailure));
     /// ```
     ///
-    /// However, these work because the sequence of cast/conversion adapts
+    /// However, these work because the sequence of cast/conversion adapts:
+    ///
     /// ```rust
     /// # use embedded_time::{traits::*, units::*};
     /// // period conversion applied first
@@ -426,9 +452,6 @@ where
     /// assert_eq!(Microseconds::<u64>::try_convert_from(Hours(1_u32)),
     ///     Ok(Microseconds(3_600_000_000_u64)));
     /// ```
-    ///
-    /// # Returns
-    /// [`None`] if the result of the conversion does not fit in the requested integer size
     fn try_convert_from(source: Source) -> Result<Self, ConversionError> {
         Self::from_ticks(source.count(), Source::PERIOD)
     }
@@ -446,8 +469,10 @@ where
     /// # use embedded_time::{traits::*, units::*};
     /// assert_eq!(Seconds(23_u64).try_convert_into(),
     ///     Ok(Seconds(23_u32)));
+    ///
     /// assert_eq!(Seconds(23_u32).try_convert_into(),
     ///     Ok(Seconds(23_u64)));
+    ///
     /// assert_eq!(Milliseconds(23_000_u64).try_convert_into(),
     ///     Ok(Seconds(23_u32)));
     /// ```
@@ -455,7 +480,8 @@ where
     /// # Errors
     /// Failure will only occur if the value does not fit in the selected destination type.
     ///
-    /// ConversionError::WouldOverflow - The conversion of periods causes an overflow:
+    /// [`ConversionError::Overflow`] - The conversion of periods causes an overflow:
+    ///
     /// ```rust
     /// # use embedded_time::{traits::*, units::*, ConversionError};
     /// use embedded_time::duration::TryConvertInto;
@@ -463,7 +489,9 @@ where
     ///     Err(ConversionError::Overflow));
     /// ```
     ///
-    /// ConversionError::CastWouldFail - The Self integer cast to that of the destination type fails:
+    /// [`ConversionError::ConversionFailure`] - The Self integer cast to that of the destination
+    /// type fails:
+    ///
     /// ```rust
     /// # use embedded_time::{traits::*, units::*, ConversionError};
     /// use embedded_time::duration::TryConvertInto;
@@ -471,7 +499,8 @@ where
     ///     Err(ConversionError::ConversionFailure));
     /// ```
     ///
-    /// However, these work because the sequence of cast/conversion adapts
+    /// However, the following work because the sequence of cast/conversion adapts:
+    ///
     /// ```rust
     /// # use embedded_time::{traits::*, units::*};
     /// // period conversion applied first

--- a/src/frequency.rs
+++ b/src/frequency.rs
@@ -1,7 +1,7 @@
 //! Representations of frequency-based values
 
 pub(crate) mod units {
-    use crate::{Period, TimeInt};
+    use crate::{ConversionError, Period, TimeInt};
     use core::{convert, ops};
 
     /// A frequency unit type
@@ -11,19 +11,35 @@ pub(crate) mod units {
     pub struct Hertz<T: TimeInt = u32>(pub T);
 
     impl<T: TimeInt> Hertz<T> {
+        /// Convert the frequency into a fractional [`Period`] in seconds
+        ///
+        /// # Examples
+        ///
         /// ```rust
         /// # use embedded_time::{Period, units::*};
-        /// assert_eq!(Hertz(1_000_u32).into_period(), <Period>::new(1, 1_000));
+        /// assert_eq!(Hertz(1_000_u32).into_period(), Ok(<Period>::new(1, 1_000)));
         /// ```
-        pub fn into_period(self) -> Period<T> {
+        ///
+        /// # Errors
+        ///
+        /// [`ConversionError::DivByZero`]
+        pub fn into_period(self) -> Result<Period<T>, ConversionError> {
             Period::from_frequency(self)
         }
 
+        /// Create a new `Frequency` from a fractional [`Period`] in seconds
+        ///
+        /// # Examples
+        ///
         /// ```rust
         /// # use embedded_time::{Period, units::*};
-        /// assert_eq!(Hertz::from_period(<Period>::new(1, 1_000)), Hertz(1_000_u32));
+        /// assert_eq!(Hertz::from_period(<Period>::new(1, 1_000)), Ok(Hertz(1_000_u32)));
         /// ```
-        pub fn from_period(period: Period<T>) -> Self {
+        ///
+        /// # Errors
+        ///
+        /// [`ConversionError::DivByZero`]
+        pub fn from_period(period: Period<T>) -> Result<Self, ConversionError> {
             period.to_frequency()
         }
     }

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -166,7 +166,8 @@ impl<Clock: crate::Clock> Instant<Clock> {
     /// Instant::<Clock>::new(u32::MAX/2 + 1));
     /// ```
     /// # Errors
-    /// [`ConversionError::Overflow`] : The duration is more than half the wrap-around period of the clock
+    /// [`ConversionError::Overflow`] : The duration is more than half the wrap-around period of the
+    /// clock
     ///
     /// ```rust
     /// # use embedded_time::{Period, units::*, Instant, ConversionError};
@@ -220,7 +221,8 @@ impl<Clock: crate::Clock> Instant<Clock> {
     /// Instant::<Clock>::new(u32::MAX/2 + 1));
     /// ```
     /// # Errors
-    /// [`ConversionError::Overflow`] : The duration is more than half the wrap-around period of the clock
+    /// [`ConversionError::Overflow`] : The duration is more than half the wrap-around period of the
+    /// clock
     ///
     /// ```rust
     /// # use embedded_time::{Period, units::*, Instant, ConversionError};
@@ -272,6 +274,7 @@ impl<Clock: crate::Clock> PartialOrd for Instant<Clock> {
     /// Calculates the difference between two `Instance`s resulting in a [`Duration`]
     ///
     /// # Examples
+    ///
     /// ```rust
     /// # use embedded_time::{Period, units::*, Instant};
     /// # #[derive(Debug)]

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -1,13 +1,13 @@
 //! An instant of time
 
-use crate::{duration::Duration, Error, TimeError};
+use crate::{duration::Duration, TimeError};
 use core::{cmp::Ordering, convert::TryFrom, ops};
 use num::traits::{WrappingAdd, WrappingSub};
 
-/// Represents an instant of time relative to a specific [`Clock`](crate::clock::Clock)
+/// Represents an instant of time relative to a specific [`Clock`](clock/trait.Clock.html)
 ///
 /// # Example
-/// Typically an `Instant` will be obtained from a [`Clock`](crate::clock::Clock)
+/// Typically an `Instant` will be obtained from a [`Clock`](clock/trait.Clock.html)
 /// ```rust
 /// # use embedded_time::{Period, traits::*, Instant};
 /// # #[derive(Debug)]
@@ -42,23 +42,17 @@ pub struct Instant<Clock: crate::Clock> {
 }
 
 impl<Clock: crate::Clock> Instant<Clock> {
-    /// Construct a new Instant with ticks of the provided [`Clock`](crate::clock::Clock).
+    /// Construct a new Instant from the provided [`Clock`](clock/trait.Clock.html)
     pub fn new(ticks: Clock::Rep) -> Self {
         Self { ticks }
     }
 
     /// Returns the [`Duration`] since the given `Instant`
     ///
-    /// # Errors
-    /// - `TimeError::DisorderedOperands`: RHS is a future `Instant`
-    /// - `TimeError::WouldOverflow`: problem coverting to the desired [`Duration`]
-    /// - `TimeError::WouldUnderflow`: problem coverting to the desired [`Duration`]
-    /// - `TimeError::CastWouldFail`: problem coverting to the desired [`Duration`]
-    ///
     /// # Examples
     /// ```rust
     /// # use embedded_time::{Period, units::*, Instant, TimeError};
-    /// # #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+    /// # #[derive(Debug)]
     /// #
     /// struct Clock;
     /// impl embedded_time::Clock for Clock {
@@ -69,33 +63,39 @@ impl<Clock: crate::Clock> Instant<Clock> {
     /// # fn now(&self) -> Result<Instant<Self>, embedded_time::clock::Error<Self::ImplError>> {unimplemented!()}
     /// }
     ///
-    /// assert_eq!(Instant::<Clock>::new(5).duration_since::<Microseconds<u64>, _>(&Instant::<Clock>::new(3)),
-    ///     Ok(Microseconds(2_000_u64)));
+    /// assert_eq!(Ok(Microseconds(2_000_u64)),
+    ///     Instant::<Clock>::new(5).duration_since::<Microseconds<u64>>(&Instant::<Clock>::new(3)));
     ///
-    /// assert_eq!(Instant::<Clock>::new(3).duration_since::<Microseconds<u64>, _>(&Instant::<Clock>::new(5)),
-    ///     Err(TimeError::DisorderedOperands));
+    /// assert_eq!(Err(TimeError::NegDuration),
+    ///     Instant::<Clock>::new(3).duration_since::<Microseconds<u64>>(&Instant::<Clock>::new(5)));
     /// ```
-    pub fn duration_since<Dur: Duration, E: Error>(&self, other: &Self) -> Result<Dur, TimeError<E>>
+    ///
+    /// # Errors
+    ///
+    /// - [`TimeError::NegDuration`] : `Instant` is in the future
+    /// - [`TimeError::Overflow`] : problem coverting to the desired [`Duration`]
+    /// - [`TimeError::ConversionFailure`] : problem coverting to the desired [`Duration`]
+    pub fn duration_since<Dur: Duration>(
+        &self,
+        other: &Self,
+    ) -> Result<Dur, TimeError<Clock::ImplError>>
     where
         Dur::Rep: TryFrom<Clock::Rep>,
     {
-        if self < other {
-            Err(TimeError::DisorderedOperands)
-        } else {
+        if self >= other {
             Dur::from_ticks(self.ticks.wrapping_sub(&other.ticks), Clock::PERIOD)
+        } else {
+            Err(TimeError::NegDuration)
         }
     }
 
     /// Returns the [`Duration`] until the given `Instant`
     ///
-    /// # Errors
-    /// - `()`: RHS is a past `Instant`
-    /// - `()`: problem coverting to desired [`Duration`]
-    ///
     /// # Examples
+    ///
     /// ```rust
     /// # use embedded_time::{Period, units::*, Instant, TimeError};
-    /// # #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+    /// # #[derive(Debug)]
     /// #
     /// struct Clock;
     /// impl embedded_time::Clock for Clock {
@@ -106,32 +106,42 @@ impl<Clock: crate::Clock> Instant<Clock> {
     /// # fn now(&self) -> Result<Instant<Self>, embedded_time::clock::Error<Self::ImplError>> {unimplemented!()}
     /// }
     ///
-    /// assert_eq!(Instant::<Clock>::new(5).duration_until::<Microseconds<u64>, _>(&Instant::<Clock>::new(7)),
+    /// assert_eq!(Instant::<Clock>::new(5).duration_until::<Microseconds<u64>>(&Instant::<Clock>::new(7)),
     ///     Ok(Microseconds(2_000_u64)));
     ///
-    /// assert_eq!(Instant::<Clock>::new(7).duration_until::<Microseconds<u64>, _>(&Instant::<Clock>::new(5)),
-    ///     Err(TimeError::DisorderedOperands));
+    /// assert_eq!(Instant::<Clock>::new(7).duration_until::<Microseconds<u64>>(&Instant::<Clock>::new(5)),
+    ///     Err(TimeError::NegDuration));
     /// ```
-    pub fn duration_until<Dur: Duration>(&self, other: &Self) -> Result<Dur, TimeError>
+    ///
+    /// # Errors
+    ///
+    /// - [`TimeError::NegDuration`] : `Instant` is in the past
+    /// - [`TimeError::Overflow`] : problem coverting to the desired [`Duration`]
+    /// - [`TimeError::ConversionFailure`] : problem coverting to the desired [`Duration`]
+    pub fn duration_until<Dur: Duration>(
+        &self,
+        other: &Self,
+    ) -> Result<Dur, TimeError<Clock::ImplError>>
     where
         Dur::Rep: TryFrom<Clock::Rep>,
     {
-        if self > other {
-            Err(TimeError::DisorderedOperands)
-        } else {
+        if self <= other {
             Dur::from_ticks(other.ticks.wrapping_sub(&self.ticks), Clock::PERIOD)
+        } else {
+            Err(TimeError::NegDuration)
         }
     }
 
-    /// Returns the [`Duration`] (in the provided units) since the beginning of time (the [`Clock`]'s 0)
+    /// Returns the [`Duration`] (in the provided units) since the beginning of time (the
+    /// [`Clock`](clock/trait.Clock.html)'s 0)
     ///
     /// If it is a _wrapping_ clock, the result is meaningless.
-    pub fn duration_since_epoch<Dur: Duration>(&self) -> Result<Dur, TimeError>
+    pub fn duration_since_epoch<Dur: Duration>(&self) -> Result<Dur, TimeError<Clock::ImplError>>
     where
         Dur::Rep: TryFrom<Clock::Rep>,
         Clock::Rep: TryFrom<Dur::Rep>,
     {
-        Self::duration_since::<Dur, _>(
+        Self::duration_since::<Dur>(
             &self,
             &Self {
                 ticks: Clock::Rep::from(0),
@@ -139,49 +149,12 @@ impl<Clock: crate::Clock> Instant<Clock> {
         )
     }
 
-    /// Subtract a duration from an instant resulting in a new, earlier instance
-    ///
-    /// # Panics
-    /// If [`Duration::into_ticks()`] returns [`None`]. In this case, `u32::MAX` of seconds
-    /// cannot be converted to the clock precision of milliseconds with u32 storage.
-    /// ```rust,should_panic
-    /// # use embedded_time::{Period, units::*, Instant};
-    /// # #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
-    /// struct Clock;
-    /// impl embedded_time::Clock for Clock {
-    ///     type Rep = u32;
-    ///     const PERIOD: Period =<Period>::new(1, 1_000);
-    ///     // ...
-    /// # type ImplError = ();
-    /// # fn now(&self) -> Result<Instant<Self>, embedded_time::clock::Error<Self::ImplError>> {unimplemented!()}
-    /// }
-    ///
-    /// Instant::<Clock>::new(1) - Seconds(u32::MAX);
-    /// ```
-    ///
-    /// If the the [`Duration`] is greater than the signed Clock::Rep max value which would cause
-    /// the result to (logically) underflow
-    /// ```rust,should_panic
-    /// # use embedded_time::{Period, units::*, Instant};
-    /// # #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
-    /// struct Clock;
-    /// impl embedded_time::Clock for Clock {
-    ///     type Rep = u32;
-    ///     const PERIOD: Period = <Period>::new(1, 1_000);
-    ///     // ...
-    /// # type ImplError = ();
-    /// # fn now(&self) -> Result<Instant<Self>, embedded_time::clock::Error<Self::ImplError>> {unimplemented!()}
-    /// }
-    ///
-    /// let _ = Instant::<Clock>::new(u32::MAX) - Milliseconds(i32::MAX as u32 + 1);
-    /// ```
-    ///
-    /// See also [`impl Sub for Duration`](duration/units/index.html#addsub)
+    /// Subtract a [`Duration`] from an `Instant` resulting in a new, earlier `Instant`
     ///
     /// # Examples
     /// ```rust
     /// # use embedded_time::{Period, units::*, Instant};
-    /// # #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+    /// # #[derive(Debug)]
     /// struct Clock;
     /// impl embedded_time::Clock for Clock {
     ///     type Rep = u32;
@@ -198,20 +171,95 @@ impl<Clock: crate::Clock> Instant<Clock> {
     /// assert_eq!(Instant::<Clock>::new(u32::MAX) - Milliseconds(i32::MAX as u32),
     /// Instant::<Clock>::new(u32::MAX/2 + 1));
     /// ```
-    pub fn wrapping_sub_duration<Dur: Duration, E: crate::Error>(
+    /// # Errors
+    /// [`TimeError::Overflow`] : The duration is more than half the wrap-around period of the clock
+    ///
+    /// ```rust
+    /// # use embedded_time::{Period, units::*, Instant, TimeError};
+    /// # #[derive(Debug)]
+    /// struct Clock;
+    /// impl embedded_time::Clock for Clock {
+    ///     type Rep = u32;
+    ///     const PERIOD: Period =<Period>::new(1, 1_000);
+    ///     // ...
+    /// # type ImplError = ();
+    /// # fn now(&self) -> Result<Instant<Self>, embedded_time::clock::Error<Self::ImplError>> {unimplemented!()}
+    /// }
+    ///
+    /// assert_eq!(Instant::<Clock>::new(0).checked_add_duration(Milliseconds(u32::MAX/2 + 1)),
+    ///     Err(TimeError::Overflow));
+    /// ```
+    pub fn checked_add_duration<Dur: Duration>(
         self,
         duration: Dur,
-    ) -> Result<Self, TimeError<E>>
+    ) -> Result<Self, TimeError<Clock::ImplError>>
+    where
+        Clock::Rep: TryFrom<Dur::Rep>,
+    {
+        let add_ticks: Clock::Rep = duration.into_ticks(Clock::PERIOD)?;
+        if add_ticks <= (<Clock::Rep as num::Bounded>::max_value() / 2.into()) {
+            Ok(Self {
+                ticks: self.ticks.wrapping_add(&add_ticks),
+            })
+        } else {
+            Err(TimeError::Overflow)
+        }
+    }
+
+    /// Adds a [`Duration`] to an `Instant` resulting in a new, later `Instant`
+    ///
+    /// # Examples
+    /// ```rust
+    /// # use embedded_time::{Period, units::*, Instant};
+    /// # #[derive(Debug)]
+    /// struct Clock;
+    /// impl embedded_time::Clock for Clock {
+    ///     type Rep = u32;
+    ///     const PERIOD: Period =<Period>::new(1, 1_000);
+    ///     // ...
+    /// # type ImplError = ();
+    /// # fn now(&self) -> Result<Instant<Self>, embedded_time::clock::Error<Self::ImplError>> {unimplemented!()}
+    /// }
+    ///
+    /// assert_eq!(Instant::<Clock>::new(800) - Milliseconds(700_u32), Instant::<Clock>::new(100));
+    /// assert_eq!(Instant::<Clock>::new(5_000) - Milliseconds(700_u64), Instant::<Clock>::new(4_300));
+    ///
+    /// // maximum duration allowed
+    /// assert_eq!(Instant::<Clock>::new(u32::MAX) - Milliseconds(i32::MAX as u32),
+    /// Instant::<Clock>::new(u32::MAX/2 + 1));
+    /// ```
+    /// # Errors
+    /// [`TimeError::Overflow`] : The duration is more than half the wrap-around period of the clock
+    ///
+    /// ```rust
+    /// # use embedded_time::{Period, units::*, Instant, TimeError};
+    /// # #[derive(Debug)]
+    /// struct Clock;
+    /// impl embedded_time::Clock for Clock {
+    ///     type Rep = u32;
+    ///     const PERIOD: Period =<Period>::new(1, 1_000);
+    ///     // ...
+    /// # type ImplError = ();
+    /// # fn now(&self) -> Result<Instant<Self>, embedded_time::clock::Error<Self::ImplError>> {unimplemented!()}
+    /// }
+    ///
+    /// assert_eq!(Instant::<Clock>::new(u32::MAX).checked_sub_duration(Milliseconds(u32::MAX/2 + 1)),
+    ///     Err(TimeError::Overflow));
+    /// ```
+    pub fn checked_sub_duration<Dur: Duration>(
+        self,
+        duration: Dur,
+    ) -> Result<Self, TimeError<Clock::ImplError>>
     where
         Clock::Rep: TryFrom<Dur::Rep>,
     {
         let sub_ticks: Clock::Rep = duration.into_ticks(Clock::PERIOD)?;
-        if sub_ticks < (<Clock::Rep as num::Bounded>::max_value() / 2.into() + 1.into()) {
+        if sub_ticks <= (<Clock::Rep as num::Bounded>::max_value() / 2.into()) {
             Ok(Self {
                 ticks: self.ticks.wrapping_sub(&sub_ticks),
             })
         } else {
-            Err(TimeError::WouldUnderflow)
+            Err(TimeError::Overflow)
         }
     }
 }
@@ -220,9 +268,7 @@ impl<Clock: crate::Clock> Copy for Instant<Clock> {}
 
 impl<Clock: crate::Clock> Clone for Instant<Clock> {
     fn clone(&self) -> Self {
-        Self {
-            ticks: self.ticks.clone(),
-        }
+        Self { ticks: self.ticks }
     }
 }
 
@@ -240,7 +286,7 @@ impl<Clock: crate::Clock> PartialOrd for Instant<Clock> {
     /// # Examples
     /// ```rust
     /// # use embedded_time::{Period, units::*, Instant};
-    /// # #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+    /// # #[derive(Debug)]
     /// struct Clock;
     /// impl embedded_time::Clock for Clock {
     ///     type Rep = u32;
@@ -268,162 +314,129 @@ impl<Clock: crate::Clock> Ord for Instant<Clock> {
     }
 }
 
-// impl<Clock: crate::Clock, Dur: Duration> ops::Add<Dur> for Instant<Clock>
-// where
-//     Clock::Rep: TryFrom<Dur::Rep>,
-// {
-//     type Output = Self;
-//
-//     /// Add a duration to an instant resulting in a new, later instance
-//     ///
-//     /// # Panics
-//     /// If [`Duration::into_ticks()`] returns [`None`]. In this case, `u32::MAX` of seconds
-//     /// cannot be converted to the clock precision of milliseconds with u32 storage.
-//     /// ```rust,should_panic
-//     /// # use embedded_time::{Period, units::*, Instant};
-//     /// # #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
-//     /// struct Clock;
-//     /// impl embedded_time::Clock for Clock {
-//     ///     type Rep = u32;
-//     ///     const PERIOD: Period =<Period>::new(1, 1_000);
-//     ///     // ...
-//     /// # type ImplError = ();
-//     /// # fn now(&self) -> Result<Instant<Self>, embedded_time::clock::Error<Self::ImplError>> {unimplemented!()}
-//     /// }
-//     ///
-//     /// Instant::<Clock>::new(1) + Seconds(u32::MAX);
-//     /// ```
-//     ///
-//     /// If the the [`Duration`] is greater than the signed Clock::Rep max value which would cause
-//     /// the result to (logically) overflow
-//     /// ```rust,should_panic
-//     /// # use embedded_time::{Period, units::*, Instant};
-//     /// # #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
-//     /// struct Clock;
-//     /// impl embedded_time::Clock for Clock {
-//     ///     type Rep = u32;
-//     ///     const PERIOD: Period =<Period>::new(1, 1_000);
-//     ///     // ...
-//     /// # type ImplError = ();
-//     /// # fn now(&self) -> Result<Instant<Self>, embedded_time::clock::Error<Self::ImplError>> {unimplemented!()}
-//     /// }
-//     ///
-//     /// let _ = Instant::<Clock>::new(0) + Milliseconds(i32::MAX as u32 + 1);
-//     /// ```
-//     ///
-//     /// See also [`impl Sub for Duration`](duration/units/index.html#addsub)
-//     ///
-//     /// # Examples
-//     /// ```rust
-//     /// # use embedded_time::{Period, units::*, Instant};
-//     /// # #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
-//     /// struct Clock;
-//     /// impl embedded_time::Clock for Clock {
-//     ///     type Rep = u32;
-//     ///     const PERIOD: Period =<Period>::new(1, 1_000);
-//     ///     // ...
-//     /// # type ImplError = ();
-//     /// # fn now(&self) -> Result<Instant<Self>, embedded_time::clock::Error<Self::ImplError>> {unimplemented!()}
-//     /// }
-//     ///
-//     /// assert_eq!(Instant::<Clock>::new(1) + Seconds(3_u32), Instant::<Clock>::new(3_001));
-//     /// assert_eq!(Instant::<Clock>::new(1) + Milliseconds(700_u32), Instant::<Clock>::new(701));
-//     /// assert_eq!(Instant::<Clock>::new(1) + Milliseconds(700_u64), Instant::<Clock>::new(701));
-//     ///
-//     /// // maximum duration allowed
-//     /// assert_eq!(Instant::<Clock>::new(0) + Milliseconds(i32::MAX as u32),
-//     /// Instant::<Clock>::new(u32::MAX/2));
-//     /// ```
-//     fn add(self, rhs: Dur) -> Self::Output {
-//         let add_ticks: Clock::Rep = rhs.into_ticks(Clock::PERIOD).unwrap();
-//         debug_assert!(add_ticks < <Clock::Rep as num::Bounded>::max_value() / 2.into() + 1.into());
-//
-//         Self {
-//             ticks: self.ticks.wrapping_add(&add_ticks),
-//         }
-//     }
-// }
+/// Add a [`Duration`] to an `Instant` resulting in a later `Instant`
+impl<Clock: crate::Clock, Dur: Duration> ops::Add<Dur> for Instant<Clock>
+where
+    Clock::Rep: TryFrom<Dur::Rep>,
+{
+    type Output = Self;
 
-// impl<Clock: crate::Clock, Dur: Duration> ops::Sub<Dur> for Instant<Clock>
-// where
-//     Clock::Rep: TryFrom<Dur::Rep>,
-// {
-//     type Output = Self;
-//
-//     /// Subtract a duration from an instant resulting in a new, earlier instance
-//     ///
-//     /// # Panics
-//     /// If [`Duration::into_ticks()`] returns [`None`]. In this case, `u32::MAX` of seconds
-//     /// cannot be converted to the clock precision of milliseconds with u32 storage.
-//     /// ```rust,should_panic
-//     /// # use embedded_time::{Period, units::*, Instant};
-//     /// # #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
-//     /// struct Clock;
-//     /// impl embedded_time::Clock for Clock {
-//     ///     type Rep = u32;
-//     ///     const PERIOD: Period =<Period>::new(1, 1_000);
-//     ///     // ...
-//     /// # type ImplError = ();
-//     /// # fn now(&self) -> Result<Instant<Self>, embedded_time::clock::Error<Self::ImplError>> {unimplemented!()}
-//     /// }
-//     ///
-//     /// Instant::<Clock>::new(1) - Seconds(u32::MAX);
-//     /// ```
-//     ///
-//     /// If the the [`Duration`] is greater than the signed Clock::Rep max value which would cause
-//     /// the result to (logically) underflow
-//     /// ```rust,should_panic
-//     /// # use embedded_time::{Period, units::*, Instant};
-//     /// # #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
-//     /// struct Clock;
-//     /// impl embedded_time::Clock for Clock {
-//     ///     type Rep = u32;
-//     ///     const PERIOD: Period = <Period>::new(1, 1_000);
-//     ///     // ...
-//     /// # type ImplError = ();
-//     /// # fn now(&self) -> Result<Instant<Self>, embedded_time::clock::Error<Self::ImplError>> {unimplemented!()}
-//     /// }
-//     ///
-//     /// let _ = Instant::<Clock>::new(u32::MAX) - Milliseconds(i32::MAX as u32 + 1);
-//     /// ```
-//     ///
-//     /// See also [`impl Sub for Duration`](duration/units/index.html#addsub)
-//     ///
-//     /// # Examples
-//     /// ```rust
-//     /// # use embedded_time::{Period, units::*, Instant};
-//     /// # #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
-//     /// struct Clock;
-//     /// impl embedded_time::Clock for Clock {
-//     ///     type Rep = u32;
-//     ///     const PERIOD: Period =<Period>::new(1, 1_000);
-//     ///     // ...
-//     /// # type ImplError = ();
-//     /// # fn now(&self) -> Result<Instant<Self>, embedded_time::clock::Error<Self::ImplError>> {unimplemented!()}
-//     /// }
-//     ///
-//     /// assert_eq!(Instant::<Clock>::new(800) - Milliseconds(700_u32), Instant::<Clock>::new(100));
-//     /// assert_eq!(Instant::<Clock>::new(5_000) - Milliseconds(700_u64), Instant::<Clock>::new(4_300));
-//     ///
-//     /// // maximum duration allowed
-//     /// assert_eq!(Instant::<Clock>::new(u32::MAX) - Milliseconds(i32::MAX as u32),
-//     /// Instant::<Clock>::new(u32::MAX/2 + 1));
-//     /// ```
-//     fn sub(self, rhs: Dur) -> Self::Output {
-//         let sub_ticks: Clock::Rep = rhs.into_ticks(Clock::PERIOD).unwrap();
-//         debug_assert!(sub_ticks < <Clock::Rep as num::Bounded>::max_value() / 2.into() + 1.into());
-//
-//         Self {
-//             ticks: self.ticks.wrapping_sub(&sub_ticks),
-//         }
-//     }
-// }
+    /// Add a [`Duration`] to an `Instant` resulting in a new, later `Instant`    
+    ///
+    /// # Examples
+    /// ```rust
+    /// # use embedded_time::{Period, units::*, Instant};
+    /// # #[derive(Debug)]
+    /// struct Clock;
+    /// impl embedded_time::Clock for Clock {
+    ///     type Rep = u32;
+    ///     const PERIOD: Period =<Period>::new(1, 1_000);
+    ///     // ...
+    /// # type ImplError = ();
+    /// # fn now(&self) -> Result<Instant<Self>, embedded_time::clock::Error<Self::ImplError>> {unimplemented!()}
+    /// }
+    ///
+    /// assert_eq!(Instant::<Clock>::new(1) + Seconds(3_u32),
+    ///     Instant::<Clock>::new(3_001));
+    /// assert_eq!(Instant::<Clock>::new(1) + Milliseconds(700_u32),
+    ///     Instant::<Clock>::new(701));
+    /// assert_eq!(Instant::<Clock>::new(1) + Milliseconds(700_u64),
+    ///     Instant::<Clock>::new(701));
+    ///
+    /// // maximum duration allowed
+    /// assert_eq!(Instant::<Clock>::new(0) + Milliseconds(i32::MAX as u32),
+    ///    Instant::<Clock>::new(u32::MAX/2));
+    /// ```
+    ///
+    /// # Panics
+    /// Virtually the same reason the integer operation would panic. Namely, if the
+    /// result overflows the type. Specifically, if the duration is more than half
+    /// the wrap-around period of the clock.
+    ///
+    /// ```rust,should_panic
+    /// # use embedded_time::{Period, units::*, Instant};
+    /// # #[derive(Debug)]
+    /// struct Clock;
+    /// impl embedded_time::Clock for Clock {
+    ///     type Rep = u32;
+    ///     const PERIOD: Period =<Period>::new(1, 1_000);
+    ///     // ...
+    /// # type ImplError = ();
+    /// # fn now(&self) -> Result<Instant<Self>, embedded_time::clock::Error<Self::ImplError>> {unimplemented!()}
+    /// }
+    ///
+    /// Instant::<Clock>::new(0) + Milliseconds(u32::MAX/2 + 1);
+    /// ```
+    fn add(self, rhs: Dur) -> Self::Output {
+        self.checked_add_duration(rhs).unwrap()
+    }
+}
+
+/// Subtract a [`Duration`] from an `Instant` resulting in an earlier `Instant`
+impl<Clock: crate::Clock, Dur: Duration> ops::Sub<Dur> for Instant<Clock>
+where
+    Clock::Rep: TryFrom<Dur::Rep>,
+{
+    type Output = Self;
+
+    /// Subtract a [`Duration`] from an `Instant` resulting in a new, earlier `Instant`
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use embedded_time::{Period, units::*, Instant};
+    /// # #[derive(Debug)]
+    /// struct Clock;
+    /// impl embedded_time::Clock for Clock {
+    ///     type Rep = u32;
+    ///     const PERIOD: Period =<Period>::new(1, 1_000);
+    ///     // ...
+    /// # type ImplError = ();
+    /// # fn now(&self) -> Result<Instant<Self>, embedded_time::clock::Error<Self::ImplError>> {unimplemented!()}
+    /// }
+    ///
+    /// assert_eq!(Instant::<Clock>::new(5_001) - Seconds(3_u32),
+    ///     Instant::<Clock>::new(2_001));
+    /// assert_eq!(Instant::<Clock>::new(800) - Milliseconds(700_u32),
+    ///     Instant::<Clock>::new(100));
+    /// assert_eq!(Instant::<Clock>::new(5_000) - Milliseconds(700_u64),
+    ///     Instant::<Clock>::new(4_300));
+    ///
+    /// // maximum duration allowed
+    /// assert_eq!(Instant::<Clock>::new(u32::MAX) - Milliseconds(i32::MAX as u32),
+    ///     Instant::<Clock>::new(u32::MAX/2 + 1));
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Virtually the same reason the integer operation would panic. Namely, if the
+    /// result overflows the type. Specifically, if the duration is more than half
+    /// the wrap-around period of the clock.
+    ///
+    /// ```rust,should_panic
+    /// # use embedded_time::{Period, units::*, Instant};
+    /// # #[derive(Debug)]
+    /// struct Clock;
+    /// impl embedded_time::Clock for Clock {
+    ///     type Rep = u32;
+    ///     const PERIOD: Period =<Period>::new(1, 1_000);
+    ///     // ...
+    /// # type ImplError = ();
+    /// # fn now(&self) -> Result<Instant<Self>, embedded_time::clock::Error<Self::ImplError>> {unimplemented!()}
+    /// }
+    ///
+    /// Instant::<Clock>::new(u32::MAX) - Milliseconds(u32::MAX/2 + 1);
+    /// ```
+    fn sub(self, rhs: Dur) -> Self::Output {
+        self.checked_sub_duration(rhs).unwrap()
+    }
+}
 
 #[cfg(test)]
 mod tests {
-    use crate::{self as time, units::*, Instant, Period};
+    use crate::{self as time, units::*, Instant, Period, TimeError};
 
-    #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+    #[derive(Debug)]
     struct Clock;
 
     impl time::Clock for Clock {
@@ -452,6 +465,6 @@ mod tests {
 
         let diff: Result<Microseconds<u64>, _> =
             Instant::<Clock>::new(5).duration_since(&Instant::<Clock>::new(6));
-        assert_eq!(diff, Err(()));
+        assert_eq!(diff, Err(TimeError::NegDuration));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,24 @@ pub mod units {
 
 /// General error-type trait implemented for all error types in this crate
 pub trait Error: fmt::Debug {}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum TimeError<E: Error = ()> {
+    CastWouldFail,
+    WouldOverflow,
+    WouldUnderflow,
+    WouldDivByZero,
+    DisorderedOperands,
+    Clock(clock::Error<E>),
+}
+impl<E: Error> Error for TimeError<E> {}
+
+impl<E: Error> From<clock::Error<E>> for TimeError<E> {
+    fn from(clock_error: clock::Error<E>) -> Self {
+        TimeError::<E>::Clock(clock_error)
+    }
+}
+
 impl Error for () {}
 impl Error for Infallible {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,7 @@ impl Error for () {}
 impl Error for Infallible {}
 
 /// Conversion errors
+#[non_exhaustive]
 #[derive(Debug, Eq, PartialEq)]
 pub enum ConversionError {
     /// Attempted type conversion failed

--- a/src/period.rs
+++ b/src/period.rs
@@ -65,6 +65,56 @@ impl<T: TimeInt> Period<T> {
         Self(Ratio::from_integer(value))
     }
 
+    /// Checked `Period` * `Period` = `Period`
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use embedded_time::{Period, ConversionError};
+    /// #
+    /// assert_eq!(<Period>::new(1000, 1).checked_mul(&<Period>::new(5,5)),
+    ///     Ok(<Period>::new(5_000, 5)));
+    ///
+    /// assert_eq!(<Period>::new(u32::MAX, 1).checked_mul(&<Period>::new(2,1)),
+    ///     Err(ConversionError::Overflow));
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// [`ConversionError::Overflow`]
+    pub fn checked_mul(&self, v: &Self) -> Result<Self, ConversionError> {
+        Ok(Self(
+            self.0.checked_mul(&v.0).ok_or(ConversionError::Overflow)?,
+        ))
+    }
+
+    /// Checked `Period` / `Period` = `Period`
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use embedded_time::{Period, ConversionError};
+    /// #
+    /// assert_eq!(<Period>::new(1000, 1).checked_div(&<Period>::new(10, 1000)),
+    ///     Ok(<Period>::new(1_000_000, 10)));
+    ///
+    /// assert_eq!(<Period>::new(1, u32::MAX).checked_div(&<Period>::new(2,1)),
+    ///     Err(ConversionError::Overflow));
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// [`ConversionError::Overflow`]
+    pub fn checked_div(&self, v: &Self) -> Result<Self, ConversionError> {
+        Ok(Self(
+            self.0.checked_div(&v.0).ok_or(ConversionError::Overflow)?,
+        ))
+    }
+
+    /// Checked `Period` * integer = `Period`
+    ///
+    /// # Examples
+    ///
     /// ```rust
     /// # use embedded_time::Period;
     /// assert_eq!(<Period>::new(1000, 1).checked_mul_integer(5_u32),
@@ -110,24 +160,7 @@ where
     ///     <Period>::new(5_000, 5));
     /// ```
     fn mul(self, rhs: Self) -> Self::Output {
-        Self(self.0 * rhs.0)
-    }
-}
-
-impl<T> num::CheckedMul for Period<T>
-where
-    T: TimeInt,
-{
-    /// ```rust
-    /// # use embedded_time::Period;
-    /// assert_eq!(<Period as num::CheckedMul>::checked_mul(&<Period>::new(1000, 1),
-    ///     &<Period>::new(5,5)), Some(<Period>::new(5_000, 5)));
-    ///
-    /// assert_eq!(<Period as num::CheckedMul>::checked_mul(&<Period>::new(u32::MAX, 1),
-    ///     &<Period>::new(2,1)), None);
-    /// ```
-    fn checked_mul(&self, v: &Self) -> Option<Self> {
-        Some(Self(self.0.checked_mul(&v.0)?))
+        self.checked_mul(&rhs).unwrap()
     }
 }
 
@@ -143,24 +176,7 @@ where
     ///     <Period>::new(1_000_000, 10));
     /// ```
     fn div(self, rhs: Self) -> Self::Output {
-        Self(self.0 / rhs.0)
-    }
-}
-
-impl<T> num::CheckedDiv for Period<T>
-where
-    T: TimeInt,
-{
-    /// ```rust
-    /// # use embedded_time::Period;
-    /// assert_eq!(<Period as num::CheckedDiv>::checked_div(&<Period>::new(1000, 1),
-    ///     &<Period>::new(10, 1000)), Some(<Period>::new(1_000_000, 10)));
-    ///
-    /// assert_eq!(<Period as num::CheckedDiv>::checked_div(&<Period>::new(1, u32::MAX),
-    ///     &<Period>::new(2,1)), None);
-    /// ```
-    fn checked_div(&self, v: &Self) -> Option<Self> {
-        Some(Self(self.0.checked_div(&v.0)?))
+        self.checked_div(&rhs).unwrap()
     }
 }
 

--- a/src/period.rs
+++ b/src/period.rs
@@ -6,7 +6,9 @@ use num::{rational::Ratio, CheckedDiv, CheckedMul};
 /// A fractional time period
 ///
 /// Used primarily to define the period of one count of a [`Duration`], [`Instant`] and [`Clock`]
-/// impl types but also convertable to/from [`Hertz`].
+/// impl types but also convertible to/from [`Hertz`].
+///
+/// The default inner type is [`u32`].
 ///
 /// [`Duration`]: duration/trait.Duration.html
 /// [`Clock`]: clock/trait.Clock.html
@@ -17,7 +19,7 @@ pub struct Period<T = u32>(Ratio<T>);
 impl<T> Period<T> {
     /// Construct a new fractional `Period`.
     ///
-    /// A reduction is **not** performed.
+    /// A reduction is **not** performed. If reduction is needed, use [`Period::new_reduce()`]
     pub const fn new(numerator: T, denominator: T) -> Self {
         Self(Ratio::new_raw(numerator, denominator))
     }

--- a/src/period.rs
+++ b/src/period.rs
@@ -136,35 +136,50 @@ impl<T: TimeInt> Period<T> {
     /// # Examples
     ///
     /// ```rust
-    /// # use embedded_time::Period;
+    /// # use embedded_time::{Period, ConversionError};
+    /// #
     /// assert_eq!(<Period>::new(1000, 1).checked_mul_integer(5_u32),
-    ///     Some(<Period>::new(5_000, 1)));
+    ///     Ok(<Period>::new(5_000, 1)));
     ///
     /// assert_eq!(<Period>::new(u32::MAX, 1).checked_mul_integer(2_u32),
-    ///     None);
+    ///     Err(ConversionError::Overflow));
     /// ```
-    pub fn checked_mul_integer(&self, multiplier: T) -> Option<Self> {
-        Some(Self(Ratio::checked_mul(
-            &self.0,
-            &Ratio::from_integer(multiplier),
-        )?))
+    ///
+    /// # Errors
+    ///
+    /// [`ConversionError::Overflow`]
+    pub fn checked_mul_integer(&self, multiplier: T) -> Result<Self, ConversionError> {
+        Ok(Self(
+            Ratio::checked_mul(&self.0, &Ratio::from_integer(multiplier))
+                .ok_or(ConversionError::Overflow)?,
+        ))
     }
 
+    /// Checked `Period` / integer = `Period`
+    ///
+    /// # Examples
+    ///
     /// ```rust
-    /// # use embedded_time::Period;
+    /// # use embedded_time::{Period, ConversionError};
+    /// #
     /// assert_eq!(<Period>::new(1000, 1).checked_div_integer(5_u32),
-    ///     Some(<Period>::new(200, 1)));
+    ///     Ok(<Period>::new(200, 1)));
+    ///
     /// assert_eq!(<Period>::new(1, 1000).checked_div_integer(5_u32),
-    ///     Some(<Period>::new(1, 5000)));
+    ///     Ok(<Period>::new(1, 5000)));
     ///
     /// assert_eq!(<Period>::new(1, u32::MAX).checked_div_integer(2_u32),
-    ///     None);
+    ///     Err(ConversionError::Overflow));
     /// ```
-    pub fn checked_div_integer(&self, divisor: T) -> Option<Self> {
-        Some(Self(Ratio::checked_div(
-            &self.0,
-            &Ratio::from_integer(divisor),
-        )?))
+    ///
+    /// # Errors
+    ///
+    /// [`ConversionError::Overflow`]
+    pub fn checked_div_integer(&self, divisor: T) -> Result<Self, ConversionError> {
+        Ok(Self(
+            Ratio::checked_div(&self.0, &Ratio::from_integer(divisor))
+                .ok_or(ConversionError::Overflow)?,
+        ))
     }
 }
 

--- a/src/time_int.rs
+++ b/src/time_int.rs
@@ -1,4 +1,4 @@
-use crate::Period;
+use crate::{Error, Period, TimeError};
 use core::{convert::TryFrom, convert::TryInto, fmt};
 
 /// The core inner-type trait for time-related types
@@ -8,6 +8,8 @@ pub trait TimeInt:
     + num::Bounded
     + num::traits::WrappingAdd
     + num::traits::WrappingSub
+    + num::CheckedAdd
+    + num::CheckedSub
     + num::CheckedMul
     + num::CheckedDiv
     + From<u32>
@@ -22,6 +24,8 @@ pub trait TimeInt:
 {
     /// A checked multiplication with a [`Period`]
     ///
+    /// Returns truncated integer
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -31,14 +35,18 @@ pub trait TimeInt:
     /// // the result is not rounded, but truncated
     /// assert_eq!(8_u32.checked_mul_period(&<Period>::new(1,3)), Some(2_u32));
     /// ```
-    fn checked_mul_period(&self, period: &Period) -> Option<Self> {
-        Some(<Self as num::CheckedDiv>::checked_div(
-            &<Self as num::CheckedMul>::checked_mul(&self, &(*period.numerator()).into())?,
+    fn checked_mul_period<E: Error>(&self, period: &Period) -> Result<Self, TimeError<E>> {
+        <Self as num::CheckedDiv>::checked_div(
+            &<Self as num::CheckedMul>::checked_mul(&self, &(*period.numerator()).into())
+                .ok_or(TimeError::WouldOverflow)?,
             &(*period.denominator()).into(),
-        )?)
+        )
+        .ok_or(TimeError::WouldDivByZero)
     }
 
     /// A checked division with a [`Period`]
+    ///
+    /// Returns truncated integer
     ///
     /// # Examples
     ///
@@ -47,11 +55,13 @@ pub trait TimeInt:
     /// assert_eq!(8_u32.checked_div_period(&<Period>::new(1,2)), Some(16_u32));
     /// assert_eq!(8_u32.checked_div_period(&<Period>::new(3,2)), Some(5_u32));
     /// ```
-    fn checked_div_period(&self, period: &Period) -> Option<Self> {
-        Some(<Self as num::CheckedDiv>::checked_div(
-            &<Self as num::CheckedMul>::checked_mul(&self, &(*period.denominator()).into())?,
+    fn checked_div_period<E: Error>(&self, period: &Period) -> Result<Self, TimeError<E>> {
+        <Self as num::CheckedDiv>::checked_div(
+            &<Self as num::CheckedMul>::checked_mul(&self, &(*period.denominator()).into())
+                .ok_or(TimeError::WouldOverflow)?,
             &(*period.numerator()).into(),
-        )?)
+        )
+        .ok_or(TimeError::WouldDivByZero)
     }
 }
 

--- a/src/time_int.rs
+++ b/src/time_int.rs
@@ -30,18 +30,18 @@ pub trait TimeInt:
     ///
     /// ```rust
     /// # use embedded_time::{Period, traits::*};
-    /// assert_eq!(8_u32.checked_mul_period(&<Period>::new(1,2)), Some(4_u32));
+    /// assert_eq!(8_u32.checked_mul_period::<()>(&<Period>::new(1,2)), Ok(4_u32));
     ///
     /// // the result is not rounded, but truncated
-    /// assert_eq!(8_u32.checked_mul_period(&<Period>::new(1,3)), Some(2_u32));
+    /// assert_eq!(8_u32.checked_mul_period::<()>(&<Period>::new(1,3)), Ok(2_u32));
     /// ```
     fn checked_mul_period<E: Error>(&self, period: &Period) -> Result<Self, TimeError<E>> {
         <Self as num::CheckedDiv>::checked_div(
             &<Self as num::CheckedMul>::checked_mul(&self, &(*period.numerator()).into())
-                .ok_or(TimeError::WouldOverflow)?,
+                .ok_or(TimeError::Overflow)?,
             &(*period.denominator()).into(),
         )
-        .ok_or(TimeError::WouldDivByZero)
+        .ok_or(TimeError::DivByZero)
     }
 
     /// A checked division with a [`Period`]
@@ -52,16 +52,16 @@ pub trait TimeInt:
     ///
     /// ```rust
     /// # use embedded_time::{Period, traits::*};
-    /// assert_eq!(8_u32.checked_div_period(&<Period>::new(1,2)), Some(16_u32));
-    /// assert_eq!(8_u32.checked_div_period(&<Period>::new(3,2)), Some(5_u32));
+    /// assert_eq!(8_u32.checked_div_period::<()>(&<Period>::new(1,2)), Ok(16_u32));
+    /// assert_eq!(8_u32.checked_div_period::<()>(&<Period>::new(3,2)), Ok(5_u32));
     /// ```
     fn checked_div_period<E: Error>(&self, period: &Period) -> Result<Self, TimeError<E>> {
         <Self as num::CheckedDiv>::checked_div(
             &<Self as num::CheckedMul>::checked_mul(&self, &(*period.denominator()).into())
-                .ok_or(TimeError::WouldOverflow)?,
+                .ok_or(TimeError::Overflow)?,
             &(*period.numerator()).into(),
         )
-        .ok_or(TimeError::WouldDivByZero)
+        .ok_or(TimeError::DivByZero)
     }
 }
 

--- a/src/time_int.rs
+++ b/src/time_int.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Period, TimeError};
+use crate::{ConversionError, Period};
 use core::{convert::TryFrom, convert::TryInto, fmt};
 
 /// The core inner-type trait for time-related types
@@ -30,18 +30,18 @@ pub trait TimeInt:
     ///
     /// ```rust
     /// # use embedded_time::{Period, traits::*};
-    /// assert_eq!(8_u32.checked_mul_period::<()>(&<Period>::new(1,2)), Ok(4_u32));
+    /// assert_eq!(8_u32.checked_mul_period(&<Period>::new(1,2)), Ok(4_u32));
     ///
     /// // the result is not rounded, but truncated
-    /// assert_eq!(8_u32.checked_mul_period::<()>(&<Period>::new(1,3)), Ok(2_u32));
+    /// assert_eq!(8_u32.checked_mul_period(&<Period>::new(1,3)), Ok(2_u32));
     /// ```
-    fn checked_mul_period<E: Error>(&self, period: &Period) -> Result<Self, TimeError<E>> {
+    fn checked_mul_period(&self, period: &Period) -> Result<Self, ConversionError> {
         <Self as num::CheckedDiv>::checked_div(
             &<Self as num::CheckedMul>::checked_mul(&self, &(*period.numerator()).into())
-                .ok_or(TimeError::Overflow)?,
+                .ok_or(ConversionError::Overflow)?,
             &(*period.denominator()).into(),
         )
-        .ok_or(TimeError::DivByZero)
+        .ok_or(ConversionError::DivByZero)
     }
 
     /// A checked division with a [`Period`]
@@ -52,16 +52,16 @@ pub trait TimeInt:
     ///
     /// ```rust
     /// # use embedded_time::{Period, traits::*};
-    /// assert_eq!(8_u32.checked_div_period::<()>(&<Period>::new(1,2)), Ok(16_u32));
-    /// assert_eq!(8_u32.checked_div_period::<()>(&<Period>::new(3,2)), Ok(5_u32));
+    /// assert_eq!(8_u32.checked_div_period(&<Period>::new(1,2)), Ok(16_u32));
+    /// assert_eq!(8_u32.checked_div_period(&<Period>::new(3,2)), Ok(5_u32));
     /// ```
-    fn checked_div_period<E: Error>(&self, period: &Period) -> Result<Self, TimeError<E>> {
+    fn checked_div_period(&self, period: &Period) -> Result<Self, ConversionError> {
         <Self as num::CheckedDiv>::checked_div(
             &<Self as num::CheckedMul>::checked_mul(&self, &(*period.denominator()).into())
-                .ok_or(TimeError::Overflow)?,
+                .ok_or(ConversionError::Overflow)?,
             &(*period.numerator()).into(),
         )
-        .ok_or(TimeError::DivByZero)
+        .ok_or(ConversionError::DivByZero)
     }
 }
 

--- a/src/time_int.rs
+++ b/src/time_int.rs
@@ -22,7 +22,7 @@ pub trait TimeInt:
     + fmt::Display
     + fmt::Debug
 {
-    /// A checked multiplication with a [`Period`]
+    /// Checked integer * [`Period`] = integer
     ///
     /// Returns truncated integer
     ///
@@ -44,7 +44,7 @@ pub trait TimeInt:
         .ok_or(ConversionError::DivByZero)
     }
 
-    /// A checked division with a [`Period`]
+    /// Checked integer / [`Period`] = integer
     ///
     /// Returns truncated integer
     ///

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,5 +1,6 @@
 use crate::{
-    duration::Duration, duration::TryConvertFrom, timer::param::*, traits::*, units::*, Instant,
+    duration, duration::Duration, duration::TryConvertFrom, timer::param::*, traits::*, units::*,
+    Instant, TimeError,
 };
 use core::{convert::TryFrom, marker::PhantomData, ops::Add, prelude::v1::*};
 
@@ -95,16 +96,16 @@ impl<Type, Clock: crate::Clock, Dur: Duration> Timer<'_, Type, Running, Clock, D
     /// **The duration is truncated, not rounded**.
     ///
     /// The units of the [`Duration`] are the same as that used to construct the `Timer`.
-    pub fn elapsed(&self) -> Dur
+    pub fn elapsed(&self) -> Result<Dur, TimeError<Clock::ImplError>>
     where
         Dur::Rep: TryFrom<Clock::Rep>,
         Clock::Rep: TryFrom<Dur::Rep>,
     {
-        self.clock
-            .now()
-            .unwrap()
-            .duration_since(&(self.expiration - self.duration))
-            .unwrap()
+        self.clock.now()?.duration_since(
+            &(self
+                .expiration
+                .wrapping_sub_duration::<_, Clock::ImplError>(self.duration)?)
+        )
     }
 
     /// Returns the [`Duration`] until the expiration of the timer
@@ -112,16 +113,19 @@ impl<Type, Clock: crate::Clock, Dur: Duration> Timer<'_, Type, Running, Clock, D
     /// **The duration is truncated, not rounded**.
     ///
     /// The units of the [`Duration`] are the same as that used to construct the `Timer`.
-    pub fn remaining(&self) -> Dur
+    pub fn remaining(&self) -> Result<Dur, TimeError<Clock::ImplError>>
     where
         Dur::Rep: TryFrom<Clock::Rep>,
         Clock::Rep: TryFrom<Dur::Rep>,
         Dur: TryConvertFrom<Seconds<u32>>,
     {
-        if let Ok(duration) = self.expiration.duration_since(&self.clock.now().unwrap()) {
-            duration
+        if let Ok(duration) = self
+            .expiration
+            .duration_since::<_, Clock::ImplError>(&self.clock.now()?)
+        {
+            Ok(duration)
         } else {
-            0.seconds().try_convert_into().unwrap()
+            0.seconds().try_convert_into()
         }
     }
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -160,6 +160,8 @@ impl<Clock: crate::Clock, Dur: Duration> Timer<'_, Periodic, Running, Clock, Dur
         Self {
             clock: self.clock,
             duration: self.duration,
+            // The `+` will never panic since this duration has already applied to the same
+            // `Instant` type without a problem
             expiration: self.expiration + self.duration,
             _type: PhantomData,
             _state: PhantomData,
@@ -175,6 +177,8 @@ impl<Clock: crate::Clock, Dur: Duration> Timer<'_, Periodic, Running, Clock, Dur
     {
         // since the timer is running, _is_expired() will return a value
         if self._is_expired() {
+            // The `+` will never panic since this duration has already applied to the same
+            // `Instant` type without a problem
             self.expiration = self.expiration + self.duration;
 
             true

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,5 +1,8 @@
 use crate::{
-    duration, duration::Duration, duration::TryConvertFrom, timer::param::*, traits::*, units::*,
+    duration::{Duration, TryConvertFrom},
+    timer::param::*,
+    traits::*,
+    units::*,
     Instant, TimeError,
 };
 use core::{convert::TryFrom, marker::PhantomData, ops::Add, prelude::v1::*};
@@ -72,17 +75,17 @@ impl<'a, Type, State, Clock: crate::Clock, Dur: Duration> Timer<'a, Type, State,
 
 impl<'a, Type, Clock: crate::Clock, Dur: Duration> Timer<'a, Type, Armed, Clock, Dur> {
     /// Start the timer from this instant
-    pub fn start(self) -> Timer<'a, Type, Running, Clock, Dur>
+    pub fn start(self) -> Result<Timer<'a, Type, Running, Clock, Dur>, TimeError<Clock::ImplError>>
     where
-        Instant<Clock>: Add<Dur, Output = Instant<Clock>>,
+        Clock::Rep: TryFrom<Dur::Rep>,
     {
-        Timer::<Type, Running, Clock, Dur> {
+        Ok(Timer::<Type, Running, Clock, Dur> {
             clock: self.clock,
             duration: self.duration,
-            expiration: self.clock.now().unwrap() + self.duration,
+            expiration: self.clock.now()?.checked_add_duration(self.duration)?,
             _type: PhantomData,
             _state: PhantomData,
-        }
+        })
     }
 }
 
@@ -104,7 +107,7 @@ impl<Type, Clock: crate::Clock, Dur: Duration> Timer<'_, Type, Running, Clock, D
         self.clock.now()?.duration_since(
             &(self
                 .expiration
-                .wrapping_sub_duration::<_, Clock::ImplError>(self.duration)?)
+                .checked_sub_duration(self.duration)?),
         )
     }
 
@@ -119,10 +122,7 @@ impl<Type, Clock: crate::Clock, Dur: Duration> Timer<'_, Type, Running, Clock, D
         Clock::Rep: TryFrom<Dur::Rep>,
         Dur: TryConvertFrom<Seconds<u32>>,
     {
-        if let Ok(duration) = self
-            .expiration
-            .duration_since::<_, Clock::ImplError>(&self.clock.now()?)
-        {
+        if let Ok(duration) = self.expiration.duration_since(&self.clock.now()?) {
             Ok(duration)
         } else {
             0.seconds().try_convert_into()
@@ -213,7 +213,7 @@ mod test {
         init_ticks();
         let clock = Clock;
 
-        let timer = clock.new_timer(1_u32.seconds()).start();
+        let timer = clock.new_timer(1_u32.seconds()).start().unwrap();
 
         thread::scope(|s| {
             let timer_handle = s.spawn(|_| timer.wait());
@@ -226,7 +226,7 @@ mod test {
 
             add_to_ticks(1_u32.seconds());
 
-            let timer = result.unwrap().start();
+            let timer = result.unwrap().start().unwrap();
             assert!(!timer.is_expired());
 
             let timer_handle = s.spawn(|_| timer.wait());
@@ -242,7 +242,11 @@ mod test {
         init_ticks();
         let clock = Clock;
 
-        let timer = clock.new_timer(1_u32.seconds()).into_periodic().start();
+        let timer = clock
+            .new_timer(1_u32.seconds())
+            .into_periodic()
+            .start()
+            .unwrap();
 
         thread::scope(|s| {
             let timer_handle = s.spawn(|_| timer.wait());
@@ -270,7 +274,11 @@ mod test {
         init_ticks();
         let clock = Clock;
 
-        let mut timer = clock.new_timer(1_u32.seconds()).into_periodic().start();
+        let mut timer = clock
+            .new_timer(1_u32.seconds())
+            .into_periodic()
+            .start()
+            .unwrap();
 
         add_to_ticks(2_u32.seconds());
 
@@ -283,27 +291,27 @@ mod test {
         init_ticks();
         let clock = Clock;
 
-        let timer = clock.new_timer(2_u32.seconds()).start();
+        let timer = clock.new_timer(2_u32.seconds()).start().unwrap();
 
         add_to_ticks(1_u32.milliseconds());
 
-        assert_eq!(timer.elapsed(), 0_u32.seconds());
-        assert_eq!(timer.remaining(), 1_u32.seconds());
+        assert_eq!(timer.elapsed(), Ok(0_u32.seconds()));
+        assert_eq!(timer.remaining(), Ok(1_u32.seconds()));
 
         add_to_ticks(1_u32.seconds());
 
-        assert_eq!(timer.elapsed(), 1_u32.seconds());
-        assert_eq!(timer.remaining(), 0_u32.seconds());
+        assert_eq!(timer.elapsed(), Ok(1_u32.seconds()));
+        assert_eq!(timer.remaining(), Ok(0_u32.seconds()));
 
         add_to_ticks(1_u32.seconds());
 
-        assert_eq!(timer.elapsed(), 2_u32.seconds());
-        assert_eq!(timer.remaining(), 0_u32.seconds());
+        assert_eq!(timer.elapsed(), Ok(2_u32.seconds()));
+        assert_eq!(timer.remaining(), Ok(0_u32.seconds()));
 
         add_to_ticks(1_u32.seconds());
 
-        assert_eq!(timer.elapsed(), 3_u32.seconds());
-        assert_eq!(timer.remaining(), 0_u32.seconds());
+        assert_eq!(timer.elapsed(), Ok(3_u32.seconds()));
+        assert_eq!(timer.remaining(), Ok(0_u32.seconds()));
     }
 
     fn init_ticks() {}
@@ -312,7 +320,7 @@ mod test {
         let ticks = TICKS.load(Ordering::SeqCst);
         let ticks = ticks
             + duration
-                .into_ticks::<<Clock as crate::Clock>::Rep>(Clock::PERIOD)
+                .into_ticks::<<Clock as crate::Clock>::Rep, ()>(Clock::PERIOD)
                 .unwrap();
         TICKS.store(ticks, Ordering::SeqCst);
     }


### PR DESCRIPTION
The `Clock` trait now has much more solid error handling, but the rest of the code needs a lot of work. One goal is to be panic-free.