### PR TITLE
Separate errors

### DIFF
--- a/src/time_int.rs
+++ b/src/time_int.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Period, TimeError};
+use crate::{ConversionError, Period};
 use core::{convert::TryFrom, convert::TryInto, fmt};
 
 /// The core inner-type trait for time-related types
@@ -30,18 +30,18 @@ pub trait TimeInt:
     ///
     /// ```rust
     /// # use embedded_time::{Period, traits::*};
-    /// assert_eq!(8_u32.checked_mul_period::<()>(&Period::new(1,2)), Ok(4_u32));
+    /// assert_eq!(8_u32.checked_mul_period(&Period::new(1,2)), Ok(4_u32));
     ///
     /// // the result is not rounded, but truncated
-    /// assert_eq!(8_u32.checked_mul_period::<()>(&Period::new(1,3)), Ok(2_u32));
+    /// assert_eq!(8_u32.checked_mul_period(&Period::new(1,3)), Ok(2_u32));
     /// ```
-    fn checked_mul_period<E: Error>(&self, period: &Period) -> Result<Self, TimeError<E>> {
+    fn checked_mul_period(&self, period: &Period) -> Result<Self, ConversionError> {
         <Self as num::CheckedDiv>::checked_div(
             &<Self as num::CheckedMul>::checked_mul(&self, &(*period.numerator()).into())
-                .ok_or(TimeError::Overflow)?,
+                .ok_or(ConversionError::Overflow)?,
             &(*period.denominator()).into(),
         )
-        .ok_or(TimeError::DivByZero)
+        .ok_or(ConversionError::DivByZero)
     }
 
     /// A checked division with a [`Period`]
@@ -52,16 +52,16 @@ pub trait TimeInt:
     ///
     /// ```rust
     /// # use embedded_time::{Period, traits::*};
-    /// assert_eq!(8_u32.checked_div_period::<()>(&Period::new(1,2)), Ok(16_u32));
-    /// assert_eq!(8_u32.checked_div_period::<()>(&Period::new(3,2)), Ok(5_u32));
+    /// assert_eq!(8_u32.checked_div_period(&Period::new(1,2)), Ok(16_u32));
+    /// assert_eq!(8_u32.checked_div_period(&Period::new(3,2)), Ok(5_u32));
     /// ```
-    fn checked_div_period<E: Error>(&self, period: &Period) -> Result<Self, TimeError<E>> {
+    fn checked_div_period(&self, period: &Period) -> Result<Self, ConversionError> {
         <Self as num::CheckedDiv>::checked_div(
             &<Self as num::CheckedMul>::checked_mul(&self, &(*period.denominator()).into())
-                .ok_or(TimeError::Overflow)?,
+                .ok_or(ConversionError::Overflow)?,
             &(*period.numerator()).into(),
         )
-        .ok_or(TimeError::DivByZero)
+        .ok_or(ConversionError::DivByZero)
     }
 }
 


### PR DESCRIPTION
Offer separate error types for traits which do not fail for implementation reasons.
An alternative would also be changing `TimeError` to something like:

```rust
pub enum TimeError<E: Error = ()> {
    Conversion(ConversionError)
    /// [`Clock`]-implementation-specific error
    Clock(clock::Error<E>),
}
```

A drawback of this approach is that the whole API does not return the same error type, although conversions are possible.