### PR TITLE
Fix division bounds

### DIFF
--- a/src/instant.rs
+++ b/src/instant.rs
@@ -176,7 +176,7 @@ impl<Clock: crate::Clock> Instant<Clock> {
     pub fn checked_add<Dur: Duration>(self, duration: Dur) -> Option<Self>
     where
         Dur: FixedPoint,
-        Clock::T: TryFrom<Dur::T>,
+        Clock::T: TryFrom<Dur::T> + core::ops::Div<Output = Clock::T>,
     {
         let add_ticks: Clock::T = duration.into_ticks(Clock::SCALING_FACTOR).ok()?;
         if add_ticks <= (<Clock::T as num::Bounded>::max_value() / 2.into()) {
@@ -214,7 +214,7 @@ impl<Clock: crate::Clock> Instant<Clock> {
     pub fn checked_sub<Dur: Duration>(self, duration: Dur) -> Option<Self>
     where
         Dur: FixedPoint,
-        Clock::T: TryFrom<Dur::T>,
+        Clock::T: TryFrom<Dur::T> + core::ops::Div<Output = Clock::T>,
     {
         let sub_ticks: Clock::T = duration.into_ticks(Clock::SCALING_FACTOR).ok()?;
         if sub_ticks <= (<Clock::T as num::Bounded>::max_value() / 2.into()) {
@@ -266,7 +266,11 @@ impl<Clock: crate::Clock> PartialOrd for Instant<Clock> {
     }
 }
 
-impl<Clock: crate::Clock> Ord for Instant<Clock> {
+impl<Clock> Ord for Instant<Clock>
+where
+    Clock: crate::Clock,
+    Clock::T: ops::Div<Output = Clock::T>,
+{
     fn cmp(&self, other: &Self) -> Ordering {
         self.ticks
             .wrapping_sub(&other.ticks)


### PR DESCRIPTION
Gets this working on nightly-2020-10-06 which has type inference changes (https://github.com/rust-lang/rust/issues/77638). I think it remains to be seen whether this specific problem was an intentional bugfix or a bug, I don't know enough about Rust type inference to know for sure how it's supposed to work. If its a bug we may not need this for long, but for now it's nice to get CI working.