### PR TITLE
Add support for deci/milli/micro hertz for rates slower than 1 hertz.

### DIFF
--- a/src/rate.rs
+++ b/src/rate.rs
@@ -509,6 +509,10 @@ pub mod units {
     impl_rate![Kibihertz, (1_024, 1), "Hertz × 1,024"];
     impl_rate![Kilohertz, (1_000, 1), "Hertz × 1,000"];
     impl_rate![Hertz, (1, 1), "Hertz"];
+    impl_rate![Decihertz, (1, 10), "Hertz / 10"];
+    impl_rate![Centihertz, (1, 100), "Hertz / 100"];
+    impl_rate![Millihertz, (1, 1_000), "Hertz / 1000"];
+    impl_rate![Microhertz, (1, 1_000_000), "Hertz / 1,000,000"];
     impl_rate![
         MebibytesPerSecond,
         (1_048_576 * 8, 1),
@@ -717,6 +721,10 @@ pub mod units {
     impl_conversion![Megahertz; Kilohertz, Hertz];
     impl_conversion![Kilohertz; Hertz];
     impl_conversion![Hertz];
+    impl_conversion![Decihertz; Hertz];
+    impl_conversion![Centihertz; Hertz];
+    impl_conversion![Millihertz; Hertz];
+    impl_conversion![Microhertz; Hertz];
 
     // The first arg implements From/TryFrom all following
     impl_conversion![MebibytesPerSecond; MebibitsPerSecond, KibibytesPerSecond, KibibitsPerSecond, BytesPerSecond, BitsPerSecond];


### PR DESCRIPTION
Adds support for sub-Hertz rates to allow for conversion of durations longer than 1 second to non-0 Hertz values.

e.g.

1 sec -> 1,000 millihertz
2 sec -> 500 millihertz
1,000 sec -> 1 millihertz