### PR TITLE
Implement mul for generic rate

### DIFF
--- a/src/rate.rs
+++ b/src/rate.rs
@@ -13,6 +13,7 @@ pub use fixed_point::FixedPoint as _;
 use num::{CheckedDiv, CheckedMul};
 #[doc(inline)]
 pub use units::*;
+use core::ops::Mul;
 
 /// An unsigned, fixed-point rate type
 ///
@@ -369,6 +370,17 @@ impl<T> Generic<T> {
 }
 
 impl<T: TimeInt> Rate for Generic<T> {}
+
+impl<T: TimeInt> Mul<T> for Generic<T> {
+    type Output = Generic<T>;
+
+    fn mul(self, rhs: T) -> Self::Output {
+        Self {
+            integer: self.integer * rhs,
+            scaling_factor: self.scaling_factor,
+        }
+    }
+}
 
 /// Rate-type units
 #[doc(hidden)]


### PR DESCRIPTION
Hi,

I am currently implementing some PLL logic and stumbled over generic rate not implementing `Mul`.

I am not sure if this was intentional or if my implementation is missing some details. I'm happy about feedback :)

I was also thinking about implementing `Div`, but I am not sure how that should affect the fraction.

Thanks for the nice library,
tdittr