### PR TITLE
Make `TimeInt` publicly available

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,6 +288,7 @@ mod timer;
 pub use clock::Clock;
 pub use instant::Instant;
 pub use timer::Timer;
+pub use time_int::TimeInt;
 
 /// Crate errors
 #[non_exhaustive]


### PR DESCRIPTION
Without access to `TimeInt`, it is impossible to write some abstraction
on top of embedded-time. There have been multiple requests from users
for making it public:
- https://github.com/FluenTech/embedded-time/issues/92#issuecomment-778550405
- https://github.com/FluenTech/embedded-time/issues/98