### PR TITLE
Removed all use of unwrap

### DIFF
--- a/src/duration.rs
+++ b/src/duration.rs
@@ -421,8 +421,7 @@ pub trait Duration: Sized + Copy {
                 Rate::T::from(*conversion_factor.numerator())
                     .checked_div(
                         &Rate::T::try_from(self.integer())
-                            .ok()
-                            .unwrap()
+                            .map_err(|_| ConversionError::Overflow)?
                             .checked_mul(&Rate::T::from(*conversion_factor.denominator()))
                             .ok_or(ConversionError::Overflow)?,
                     )
@@ -457,7 +456,11 @@ impl<T: TimeInt> PartialOrd<Generic<T>> for Generic<T> {
 
 impl<T: TimeInt> Ord for Generic<T> {
     fn cmp(&self, rhs: &Generic<T>) -> core::cmp::Ordering {
-        self.partial_cmp(rhs).unwrap()
+        if let Some(v) = self.partial_cmp(rhs) {
+            v
+        } else {
+            panic!("Cmp failed")
+        }
     }
 }
 
@@ -591,7 +594,11 @@ pub mod units {
 
                 // Symmetric version of Instant + Duration
                 fn add(self, rhs: crate::Instant<Clock>) -> Self::Output {
-                    rhs.checked_add(self).unwrap()
+                    if let Some(v) = rhs.checked_add(self) {
+                        v
+                    } else {
+                        panic!("Add failed")
+                    }
                 }
             }
 
@@ -936,7 +943,11 @@ pub mod units {
                 {
                     /// See [Converting between `Duration`s](trait.Duration.html#converting-between-durations)
                     fn from(small: $small<T>) -> Self {
-                        fixed_point::FixedPoint::from_ticks(small.integer(), $small::<T>::SCALING_FACTOR).ok().unwrap()
+                        if let Ok(v) = fixed_point::FixedPoint::from_ticks(small.integer(), $small::<T>::SCALING_FACTOR) {
+                            v
+                        } else {
+                            panic!("From failed")
+                        }
                     }
                 }
 
@@ -944,7 +955,11 @@ pub mod units {
                 {
                     /// See [Converting between `Duration`s](trait.Duration.html#converting-between-durations)
                     fn from(small: $small<u32>) -> Self {
-                        fixed_point::FixedPoint::from_ticks(small.integer(), $small::<u32>::SCALING_FACTOR).ok().unwrap()
+                        if let Ok(v) = fixed_point::FixedPoint::from_ticks(small.integer(), $small::<u32>::SCALING_FACTOR) {
+                            v
+                        } else {
+                            panic!("From failed")
+                        }
                     }
                 }
 
@@ -983,7 +998,11 @@ pub mod units {
                 {
                     /// See [Converting between `Duration`s](trait.Duration.html#converting-between-durations)
                     fn from(big: $big<u32>) -> Self {
-                        fixed_point::FixedPoint::from_ticks(big.integer(), $big::<u32>::SCALING_FACTOR).ok().unwrap()
+                        if let Ok(v) = fixed_point::FixedPoint::from_ticks(big.integer(), $big::<u32>::SCALING_FACTOR) {
+                            v
+                        } else {
+                            panic!("From failed")
+                        }
                     }
                 }
 

--- a/src/fixed_point.rs
+++ b/src/fixed_point.rs
@@ -151,7 +151,12 @@ pub trait FixedPoint: Sized + Copy {
     where
         Self: TryFrom<Rhs>,
     {
-        Self::new(self.integer() + Self::try_from(rhs).ok().unwrap().integer())
+        let v = if let Ok(v) = Self::try_from(rhs) {
+            v
+        } else {
+            panic!("Add failed")
+        };
+        Self::new(self.integer() + v.integer())
     }
 
     /// Panicky subtraction
@@ -160,7 +165,13 @@ pub trait FixedPoint: Sized + Copy {
     where
         Self: TryFrom<Rhs>,
     {
-        Self::new(self.integer() - Self::try_from(rhs).ok().unwrap().integer())
+        let v = if let Ok(v) = Self::try_from(rhs) {
+            v
+        } else {
+            panic!("Sub failed")
+        };
+
+        Self::new(self.integer() - v.integer())
     }
 
     /// Panicky multiplication

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -334,7 +334,11 @@ where
     /// Instant::<Clock>::new(0) + Milliseconds(u32::MAX/2 + 1);
     /// ```
     fn add(self, rhs: Dur) -> Self::Output {
-        self.checked_add(rhs).unwrap()
+        if let Some(v) = self.checked_add(rhs) {
+            v
+        } else {
+            panic!("Add failed")
+        }
     }
 }
 
@@ -392,7 +396,11 @@ where
     /// Instant::<Clock>::new(u32::MAX) - Milliseconds(u32::MAX/2 + 1);
     /// ```
     fn sub(self, rhs: Dur) -> Self::Output {
-        self.checked_sub(rhs).unwrap()
+        if let Some(v) = self.checked_sub(rhs) {
+            v
+        } else {
+            panic!("Sub failed")
+        }
     }
 }
 
@@ -437,7 +445,11 @@ impl<Clock: crate::Clock> ops::Sub<Instant<Clock>> for Instant<Clock> {
     /// Instant::<Clock>::new(0) - Instant::<Clock>::new(1);
     /// ```
     fn sub(self, rhs: Instant<Clock>) -> Self::Output {
-        self.checked_duration_since(&rhs).unwrap()
+        if let Some(v) = self.checked_duration_since(&rhs) {
+            v
+        } else {
+            panic!("Sub failed")
+        }
     }
 }
 

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -329,8 +329,7 @@ pub trait Rate: Sized + Copy {
                 Duration::T::from(*conversion_factor.numerator())
                     .checked_div(
                         &Duration::T::try_from(self.integer())
-                            .ok()
-                            .unwrap()
+                            .map_err(|_| ConversionError::Overflow)?
                             .checked_mul(&Duration::T::from(*conversion_factor.denominator()))
                             .ok_or(ConversionError::Overflow)?,
                     )
@@ -600,7 +599,11 @@ pub mod units {
             {
                 /// See [Converting between `Rate`s](trait.Rate.html#converting-between-rates)
                 fn from(small: $small<T>) -> Self {
-                    fixed_point::FixedPoint::from_ticks(small.integer(), $small::<T>::SCALING_FACTOR).ok().unwrap()
+                    if let Ok(v) = fixed_point::FixedPoint::from_ticks(small.integer(), $small::<T>::SCALING_FACTOR) {
+                        v
+                    } else {
+                        panic!("From failed")
+                    }
                 }
             }
 
@@ -608,7 +611,11 @@ pub mod units {
             {
                 /// See [Converting between `Rate`s](trait.Rate.html#converting-between-rates)
                 fn from(small: $small<u32>) -> Self {
-                    fixed_point::FixedPoint::from_ticks(small.integer(), $small::<u32>::SCALING_FACTOR).ok().unwrap()
+                    if let Ok(v) = fixed_point::FixedPoint::from_ticks(small.integer(), $small::<u32>::SCALING_FACTOR) {
+                        v
+                    } else {
+                        panic!("From failed")
+                    }
                 }
             }
 
@@ -630,7 +637,11 @@ pub mod units {
             {
                /// See [Converting between `Rate`s](trait.Rate.html#converting-between-rates)
                 fn from(big: $big<u32>) -> Self {
-                    fixed_point::FixedPoint::from_ticks(big.integer(), $big::<u32>::SCALING_FACTOR).ok().unwrap()
+                    if let Ok(v) = fixed_point::FixedPoint::from_ticks(big.integer(), $big::<u32>::SCALING_FACTOR) {
+                        v
+                    } else {
+                        panic!("From failed")
+                    }
                 }
             }
 


### PR DESCRIPTION
I removed all use of unwrap to help combat fmt bloat we see in downstream crates.

Was not used as much as I expected.

Closes #84