### PR TITLE
add support for defmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --doc --all-features
+          args: --doc --features serde
 
       - name: Clippy
         uses: actions-rs/cargo@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- added optional support for [defmt](https://github.com/knurling-rs/defmt)
+
 [unreleased]: https://github.com/FluenTech/embedded-time/compare/v0.12.0...HEAD
 
 ## [0.12.0] - 2021-05-30

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = ["examples"]
 [dependencies]
 num = { version = "0.3.0", default-features = false }
 serde = { version = "1.0.0", default-features = false, features = ["derive"], optional = true }
-defmt = { version = "0.2", optional = true }
+defmt = { version = "0.2.3", optional = true }
 
 [dev-dependencies]
 crossbeam-utils = "0.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = ["examples"]
 [dependencies]
 num = { version = "0.3.0", default-features = false }
 serde = { version = "1.0.0", default-features = false, features = ["derive"], optional = true }
+defmt = { version = "0.2", optional = true }
 
 [dev-dependencies]
 crossbeam-utils = "0.7.2"

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -9,6 +9,7 @@ use core::hash::Hash;
 /// Potential `Clock` errors
 #[non_exhaustive]
 #[derive(Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     /// Exact cause of failure is unknown
     Unspecified,
@@ -34,7 +35,11 @@ impl Default for Error {
 /// software [`Timer`]s can be spawned from a `Clock` object.
 pub trait Clock: Sized {
     /// The type to hold the tick count
+    #[cfg(not(feature = "defmt"))]
     type T: TimeInt + Hash;
+    /// The type to hold the tick count
+    #[cfg(feature = "defmt")]
+    type T: TimeInt + Hash + defmt::Format;
 
     /// The duration of one clock tick in seconds, AKA the clock precision.
     const SCALING_FACTOR: Fraction;

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -438,6 +438,7 @@ pub trait Duration: Sized + Copy {
 /// The purpose of this type is to allow a simple `Duration` object that can be defined at run-time.
 /// It does this by replacing the `const` _scaling factor_ with a struct field.
 #[derive(Copy, Clone, Debug, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Generic<T> {
     integer: T,
     scaling_factor: Fraction,
@@ -557,6 +558,13 @@ pub mod units {
                 /// See [Formatting](trait.Duration.html#formatting)
                 fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
                     fmt::Display::fmt(&self.0, f)
+                }
+            }
+
+            #[cfg(feature = "defmt")]
+            impl<T: TimeInt + defmt::Format> defmt::Format for $name<T> {
+                fn format(&self, fmt: defmt::Formatter) {
+                    defmt::write!(fmt, "{}", self.0)
                 }
             }
 

--- a/src/fraction.rs
+++ b/src/fraction.rs
@@ -180,5 +180,12 @@ impl Default for Fraction {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl defmt::Format for Fraction {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "{} / {}", self.numerator(), self.denominator())
+    }
+}
+
 #[cfg(test)]
 mod tests {}

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -46,6 +46,7 @@ use num::traits::{WrappingAdd, WrappingSub};
 /// Instant::<SomeClock>::new(23);
 /// ```
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Instant<Clock: crate::Clock> {
     ticks: Clock::T,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,6 +295,7 @@ pub use timer::Timer;
 /// Crate errors
 #[non_exhaustive]
 #[derive(Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TimeError {
     /// Exact cause of failure is unknown
     Unspecified,
@@ -325,6 +326,7 @@ impl Default for TimeError {
 /// Conversion errors
 #[non_exhaustive]
 #[derive(Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ConversionError {
     /// Exact cause of failure is unknown
     Unspecified,

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -13,28 +13,34 @@ use core::{convert::TryFrom, marker::PhantomData, ops::Add, prelude::v1::*};
 pub mod param {
     /// Parameter not set
     #[derive(Debug, Hash)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct None;
 
     /// Timer is ready to start
     #[derive(Debug, Hash)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct Armed;
 
     /// Timer is running
     #[derive(Debug, Hash)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct Running;
 
     /// Timer will automatically restart when it expires
     #[derive(Debug, Hash)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct Periodic;
 
     /// Timer will stop when it expires
     #[derive(Debug, Hash)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct OneShot;
 }
 
 /// A `Timer` counts toward an expiration, can be polled for elapsed and remaining time, and can be
 /// one-shot or continuous/periodic.
 #[derive(Debug, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Timer<'a, Type, State, Clock: crate::Clock, Dur: Duration> {
     clock: &'a Clock,
     duration: Dur,


### PR DESCRIPTION
This pull-request adds optional support for [`defmt`](https://github.com/knurling-rs/defmt).

`defmt`, like this crate aims to solve a problem in the core library, namely the code-size of the formatting logic.