### PR TITLE
Manual Ord & Eq for Fraction

### DIFF
--- a/src/fraction.rs
+++ b/src/fraction.rs
@@ -1,5 +1,6 @@
 //! Fractional/Rational values
 use crate::ConversionError;
+use core::cmp::Ordering;
 use core::ops;
 use num::{rational::Ratio, CheckedDiv, CheckedMul, Zero};
 
@@ -12,7 +13,7 @@ use num::{rational::Ratio, CheckedDiv, CheckedMul, Zero};
 /// [`Rate`]: rate/trait.Rate.html
 /// [`Clock`]: clock/trait.Clock.html
 /// [`Instant`]: instant/struct.Instant.html
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct Fraction(Ratio<u32>);
 
 impl Fraction {
@@ -32,6 +33,46 @@ impl Fraction {
     /// Return the denominator of the fraction
     pub const fn denominator(&self) -> u32 {
         *self.0.denom()
+    }
+
+    const fn const_eq(&self, other: &Self) -> bool {
+        (self.numerator() as u64) * (other.denominator() as u64)
+            == (self.denominator() as u64) * (other.numerator() as u64)
+    }
+
+    const fn const_cmp(&self, other: &Self) -> Ordering {
+        let ad = (self.numerator() as u64) * (other.denominator() as u64);
+        let bc = (self.denominator() as u64) * (other.numerator() as u64);
+        if ad < bc {
+            Ordering::Less
+        } else if ad == bc {
+            Ordering::Equal
+        } else {
+            Ordering::Greater
+        }
+    }
+}
+
+impl PartialEq for Fraction {
+    #[inline(always)]
+    fn eq(&self, other: &Self) -> bool {
+        self.const_eq(other)
+    }
+}
+
+impl Eq for Fraction {}
+
+impl PartialOrd for Fraction {
+    #[inline(always)]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.const_cmp(other))
+    }
+}
+
+impl Ord for Fraction {
+    #[inline(always)]
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.const_cmp(other)
     }
 }
 
@@ -184,6 +225,23 @@ impl Default for Fraction {
 impl defmt::Format for Fraction {
     fn format(&self, fmt: defmt::Formatter) {
         defmt::write!(fmt, "{} / {}", self.numerator(), self.denominator())
+    }
+}
+
+use core::hash::{Hash, Hasher};
+impl Hash for Fraction {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        recurse(self.numerator(), self.denominator(), state);
+
+        fn recurse<H: Hasher>(numer: u32, denom: u32, state: &mut H) {
+            if denom != 0 {
+                let (int, rem) = ((numer / denom), (numer % denom));
+                int.hash(state);
+                recurse(denom, rem, state);
+            } else {
+                denom.hash(state);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
I've tried to use `embedded-time` for `stm32f4xx-hal` (see https://github.com/stm32-rs/stm32f4xx-hal/pull/360), but I see problem. Only `TryInto<Hertz>` is implemented for `Kilohertz`/`Megahertz`. And compiler can't optimize it as expected.

There is part of `blinky-timer-irq` example from `stm32f4xx-hal` in the table. And code size in release mode.
As you can see, this PR doesn't solve the problem, but makes it lesser.
| code                                                                                                                                   | before "s" | after "s" | before "z" | after "z" |
|---------------------------------------------------------------------------------------------------------------------|--------|-------|-------|-------|
| ```rust let clocks = rcc.cfgr.sysclk(16.MHz())             .pclk1(8.MHz())             .freeze(); ``` | 3364   | 2948  | 3972 | 3780 |
| ```rust let clocks = rcc.cfgr.sysclk(16_000_000.Hz()).pclk1(8.MHz())             .freeze(); ``` | 2380   | **1448**  | 2644 | 2452 |
| ```rust let clocks = rcc.cfgr.sysclk(16.MHz())             .pclk1(8_000_000.Hz()).freeze(); ``` | 3140   | **1448**  | 3924 | 3732 |
| ```rust let clocks = rcc.cfgr.sysclk(16_000_000.Hz()).pclk1(8_000_000.Hz()).freeze(); ``` | **1448**   | **1448**  | 1836 | 1836 |