### PR TITLE
Add scaling_factor method to FixedPoint

### DIFF
--- a/src/fixed_point.rs
+++ b/src/fixed_point.rs
@@ -29,6 +29,11 @@ pub trait FixedPoint: Sized + Copy {
     /// ```
     fn integer(&self) -> Self::T;
 
+    /// Returns the _scaling factor_ [`Fraction`] part
+    fn scaling_factor(&self) -> Fraction {
+        Self::SCALING_FACTOR
+    }
+
     /// Constructs a `FixedPoint` value from _integer_ and _scaling-factor_ ([`Fraction`]) parts
     ///
     /// # Errors

--- a/src/fixed_point.rs
+++ b/src/fixed_point.rs
@@ -30,6 +30,12 @@ pub trait FixedPoint: Sized + Copy {
     fn integer(&self) -> Self::T;
 
     /// Returns the _scaling factor_ [`Fraction`] part
+    ///
+    /// ```rust
+    /// # use embedded_time::{ rate::*};
+    /// #
+    /// assert_eq!(Kilohertz(45_u32).scaling_factor(), Fraction::new(1_000, 1));
+    /// ```
     fn scaling_factor(&self) -> Fraction {
         Self::SCALING_FACTOR
     }


### PR DESCRIPTION
For `duration::Generic` or `rate::Generic` getting the scaling factor is as easy as calling `rate.scaling_factor()`.

For examle today I tried to muliply a `Hertz` variable with a `Microsecond` variable. To do this now, needs the following

```rust
use embedded_time::{
    fixed_point::FixedPoint,
    time::Microseconds,
    rate::Hertz,
};

// not really needed and sublte bugs are introduced if the type (and its internal scaling factor) will change
let time = Microseconds(10);
let rate = Hertz(1_000);

let calculation_result = time.integer() * rate.integer() * <Microseconds as FixedPoint>::SCALING_FACTOR;
```

This could also introduce subtle bugs, as the `SCALING_FACTOR` call is not bound to the `time` variable. 

Providing a method, which just returns the value of the associated constant, allows this:

```diff

-let calculation_result = time.integer() * rate.integer() * <Microseconds as FixedPoint>::SCALING_FACTOR;
+let calculation_result = time.integer() * rate.integer() * time.scaling_factor();
```

The ergonomics of the `Generic` types are quite nice, but I miss it for the other types. 