### PR TITLE
Fixed generic comparison where the destination integer is larger

### DIFF
--- a/src/duration.rs
+++ b/src/duration.rs
@@ -650,11 +650,38 @@ pub mod units {
                 }
             }
 
-            impl<T: TimeInt> From<$name<T>> for Generic<T> {
+            impl<T1, T2> From<$name<T1>> for Generic<T2>
+            where
+                T1: TimeInt,
+                T2: TimeInt + From<T1>,
+            {
                 /// See [Converting to a `Generic`
                 /// `Duration`](trait.Duration.html#converting-to-a-generic-duration)
-                fn from(duration: $name<T>) -> Self {
-                    Self::new(duration.integer(), $name::<T>::SCALING_FACTOR)
+                fn from(duration: $name<T1>) -> Self {
+                    Self::new(duration.integer().into(), $name::<T1>::SCALING_FACTOR)
+                }
+            }
+
+            impl<T1, T2> PartialEq<$name<T1>> for Generic<T2>
+            where
+                T1: TimeInt,
+                T2: TimeInt + From<T1>,
+            {
+                fn eq(&self, rhs: &$name<T1>) -> bool {
+                    self.eq(rhs.into())
+                }
+            }
+
+            impl<T1, T2> PartialOrd<$name<T1>> for Generic<T2>
+            where
+                T1: TimeInt,
+                T2: TimeInt + From<T1>,
+            {
+                fn partial_cmp(&self, rhs: &$name<T1>) -> Option<core::cmp::Ordering> {
+                    self.partial_cmp(&Self::new(
+                        rhs.integer().into(),
+                        $name::<T1>::SCALING_FACTOR,
+                    ))
                 }
             }
         };

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -50,8 +50,9 @@ fn comparisons() {
     assert!(Microseconds(5_u32) < Microseconds(u64::MAX));
     assert!(Microseconds(u64::MAX) > Microseconds(5_u32));
 
-    assert!(Generic::new(32_768, Fraction::new(1, 32_768)) < Milliseconds(10_000_u32).into());
-    assert!(Generic::new(20 * 32_768, Fraction::new(1, 32_768)) > Milliseconds(10_000_u32).into());
+    assert!(Generic::new(32_768_u64, Fraction::new(1, 32_768)) < Milliseconds(10_000_u32));
+    assert!(Generic::new(32_768_u32, Fraction::new(1, 32_768)) < Milliseconds(10_000_u32));
+    assert!(Generic::new(20 * 32_768_u32, Fraction::new(1, 32_768)) > Milliseconds(10_000_u32));
     assert!(
         Generic::new(1_000u32, Fraction::new(1, 1_000))
             == Generic::new(2_000u32, Fraction::new(1, 2_000))


### PR DESCRIPTION
I found an issue in when comparing durations where the `Generic` is of `u64` and eg `Milliseconds` is u32 would fail.

This fixes that. Could we include this in the `0.13` release @PTaylor-us ?
We found that users hit this easily in RTIC.